### PR TITLE
Preprocess constructor args

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "account": "yarn workspace @ss/stylus account",
     "chain": "./nitro-devnode/start-chain-with-cors.sh",
+    "clean-contracts": "yarn workspace @ss/stylus clean-contracts",
     "fork": "yarn workspace @ss/stylus fork",
     "deploy": "yarn workspace @ss/stylus deploy",
     "export-abi": "yarn workspace @ss/stylus export-abi",

--- a/packages/stylus/package.json
+++ b/packages/stylus/package.json
@@ -11,7 +11,7 @@
     "deploy": "ts-node scripts/deploy_wrapper.ts",
     "test:networks": "ts-node scripts/test_network.ts",
     "export-abi": "ts-node scripts/export_abi.ts",
-    "clean": "rm -rf dist",
+    "clean-contracts": "git clean -xdf -e .env -e your-contract/ -e node_modules/",
     "test": "cargo test",
     "lint": "eslint scripts --ext .ts",
     "lint:fix": "eslint scripts --ext .ts --fix",

--- a/packages/stylus/scripts/utils/command.ts
+++ b/packages/stylus/scripts/utils/command.ts
@@ -10,7 +10,7 @@ export async function buildDeployCommand(
 
   const constructorArgs =
     deployOptions.constructorArgs && deployOptions.constructorArgs.length > 0
-      ? `--constructor-args ${deployOptions.constructorArgs.map((arg) => `'${arg}'`).join(" ")}`
+      ? `--constructor-args ${deployOptions.constructorArgs.map((arg) => `'${String(arg)}'`).join(" ")}`
       : "";
 
   if (deployOptions.estimateGas) {

--- a/packages/stylus/scripts/utils/type.ts
+++ b/packages/stylus/scripts/utils/type.ts
@@ -13,7 +13,7 @@ export interface DeployCommandOptions
 export interface DeployOptions {
   contract?: string;
   name?: string;
-  constructorArgs?: string[];
+  constructorArgs?: NonNullable<unknown>[];
   network?: string;
   estimateGas?: boolean;
   maxFee?: string;


### PR DESCRIPTION
## Description

Preprocess constructor args before calling to deploy.
Now all primitive datatype can be pass into constructor and will be parse into string:
```ts
  await deployStylusContract({
    contract: "your-contract",
    constructorArgs: [
      config.deployerAddress!,
      "Building Unstoppable Apps!!!",
      true,
      10,
      -5,
    ],
    ...deployOptions,
  });
 ```
to
```bash
  --constructor-args '0x3f1Eae7D46d88F08fc2F8ed27FCb2AB183EB2d0E' 'Building Unstoppable Apps!!!' 'true' '10' '-5'
```

##Other feature:
use `yarn clean-contracts` to clean untrack contracts folders
