### PR TITLE
fix: parse deployments with multiple constructors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ss",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": true,
   "workspaces": {
     "packages": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ss",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "workspaces": {
     "packages": [

--- a/packages/stylus/scripts/utils/command.ts
+++ b/packages/stylus/scripts/utils/command.ts
@@ -8,13 +8,6 @@ export async function buildDeployCommand(
 ) {
   let baseCommand = `cargo stylus deploy --endpoint='${config.chain?.rpcUrl}' --private-key='${config.privateKey}'`;
 
-  if (
-    deployOptions.constructorArgs &&
-    deployOptions.constructorArgs.length > 0
-  ) {
-    baseCommand += ` --constructor-args='${deployOptions.constructorArgs.join(" ")}'`;
-  }
-
   if (deployOptions.estimateGas) {
     return `${baseCommand} --estimate-gas`;
   }
@@ -25,6 +18,13 @@ export async function buildDeployCommand(
 
   if (deployOptions.maxFee) {
     baseCommand += ` --max-fee-per-gas-gwei=${deployOptions.maxFee}`;
+  }
+
+  if (
+    deployOptions.constructorArgs &&
+    deployOptions.constructorArgs.length > 0
+  ) {
+    baseCommand += ` --constructor-args ${deployOptions.constructorArgs.map((arg) => `"${arg}"`).join(" ")} `;
   }
 
   return baseCommand;

--- a/packages/stylus/scripts/utils/command.ts
+++ b/packages/stylus/scripts/utils/command.ts
@@ -8,13 +8,15 @@ export async function buildDeployCommand(
 ) {
   let baseCommand = `cargo stylus deploy --endpoint='${config.chain?.rpcUrl}' --private-key='${config.privateKey}'`;
 
-  const constructorArgs =
-    deployOptions.constructorArgs && deployOptions.constructorArgs.length > 0
-      ? `--constructor-args ${deployOptions.constructorArgs.map((arg) => `'${arg}'`).join(" ")}`
-      : "";
+  if (
+    deployOptions.constructorArgs &&
+    deployOptions.constructorArgs.length > 0
+  ) {
+    baseCommand += ` --constructor-args='${deployOptions.constructorArgs.join(" ")}'`;
+  }
 
   if (deployOptions.estimateGas) {
-    return `${baseCommand} --estimate-gas ${constructorArgs}`;
+    return `${baseCommand} --estimate-gas`;
   }
 
   if (!deployOptions.verify) {
@@ -25,7 +27,7 @@ export async function buildDeployCommand(
     baseCommand += ` --max-fee-per-gas-gwei=${deployOptions.maxFee}`;
   }
 
-  return `${baseCommand} ${constructorArgs}`;
+  return baseCommand;
 }
 
 export async function estimateGasPrice(


### PR DESCRIPTION
Fixed by parsing constructor tokens and putting constructor args in the end