### PR TITLE
fix: yarn deploy not working due to workaround

### DIFF
--- a/packages/stylus/your-contract/src/lib.rs
+++ b/packages/stylus/your-contract/src/lib.rs
@@ -170,15 +170,15 @@ impl IOwnable for YourContract {
     }
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn emit_log(_pointer: *const u8, _len: usize, _: usize) {}
-
-#[no_mangle]
-pub unsafe extern "C" fn msg_sender(_sender: *mut u8) {}
 #[cfg(test)]
 mod test {
     use super::*;
     use stylus_sdk::testing::*;
+
+    #[no_mangle]
+    pub unsafe extern "C" fn emit_log(_pointer: *const u8, _len: usize, _: usize) {}
+    #[no_mangle]
+    pub unsafe extern "C" fn msg_sender(_sender: *mut u8) {}
 
     #[test]
     fn test_your_contract() {


### PR DESCRIPTION
## Description

fixed yarn deploy not working due to workaround issue.

## Additional Information

- [X] I have read the [contributing docs](/Arb-Stylus/scaffold-stylus/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [X] This is not a duplicate of any [existing pull request](https://github.com/Arb-Stylus/scaffold-stylus/pulls)

## Related Issues

_Closes #{issue number}_

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._
