### PR TITLE
refactor: deployment flow

### DIFF
--- a/packages/stylus/scripts/deploy.ts
+++ b/packages/stylus/scripts/deploy.ts
@@ -1,5 +1,5 @@
 import deployStylusContract from "./deploy_contract";
-import { getDeploymentConfig, printDeployedAddresses } from "./utils/";
+import { getDeploymentConfig, getRpcUrlFromChain, printDeployedAddresses } from "./utils/";
 import { DeployOptions } from "./utils/type";
 import { config as dotenvConfig } from "dotenv";
 import * as path from "path";
@@ -16,7 +16,7 @@ if (fs.existsSync(envPath)) {
 export default async function deployScript(deployOptions: DeployOptions) {
   const config = getDeploymentConfig(deployOptions);
 
-  console.log(`📡 Using endpoint: ${config.chain?.rpcUrl}`);
+  console.log(`📡 Using endpoint: ${getRpcUrlFromChain(config.chain)}`);
   if (config.chain) {
     console.log(`🌐 Network: ${config.chain?.name}`);
     console.log(`🔗 Chain ID: ${config.chain?.id}`);
@@ -36,7 +36,7 @@ export default async function deployScript(deployOptions: DeployOptions) {
   // await deployStylusContract({
   //   contract: "counter",
   //   constructorArgs: [100],
-  //   isOrbit: true,
+  //   useInitializeFunction: true,
   //   ...deployOptions,
   // });
 
@@ -50,5 +50,5 @@ export default async function deployScript(deployOptions: DeployOptions) {
 
   // Print the deployed addresses
   console.log("\n\n");
-  printDeployedAddresses(config.deploymentDir, config.chain?.id);
+  printDeployedAddresses(config.deploymentDir, config.chain.id.toString());
 }

--- a/packages/stylus/scripts/deploy.ts
+++ b/packages/stylus/scripts/deploy.ts
@@ -1,5 +1,9 @@
 import deployStylusContract from "./deploy_contract";
-import { getDeploymentConfig, getRpcUrlFromChain, printDeployedAddresses } from "./utils/";
+import {
+  getDeploymentConfig,
+  getRpcUrlFromChain,
+  printDeployedAddresses,
+} from "./utils/";
 import { DeployOptions } from "./utils/type";
 import { config as dotenvConfig } from "dotenv";
 import * as path from "path";
@@ -36,7 +40,7 @@ export default async function deployScript(deployOptions: DeployOptions) {
   // await deployStylusContract({
   //   contract: "counter",
   //   constructorArgs: [100],
-  //   useInitializeFunction: true,
+  //   isOrbit: true,
   //   ...deployOptions,
   // });
 

--- a/packages/stylus/scripts/deploy_contract.ts
+++ b/packages/stylus/scripts/deploy_contract.ts
@@ -4,7 +4,6 @@ import {
   executeCommand,
   extractDeploymentInfo,
   saveDeployment,
-  ORBIT_CHAINS,
   getBlockExplorerUrlFromChain,
   getRpcUrlFromChain,
   getContractData,
@@ -16,6 +15,7 @@ import { DeployOptions } from "./utils/type";
 import { buildDeployCommand } from "./utils/command";
 import { Abi, createPublicClient, createWalletClient, http } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
+import { arbitrumNitro } from "../../nextjs/utils/scaffold-stylus/supportedChains";
 
 /**
  * Deploy a single contract using cargo stylus
@@ -32,9 +32,6 @@ export default async function deployStylusContract(
   ensureDeploymentDirectory(config.deploymentDir);
 
   console.log(`📄 Contract name: ${config.contractName}`);
-
-  const orbitChain = ORBIT_CHAINS.find((chain) => chain.id === config.chain.id);
-  if (orbitChain) deployOptions.useInitializeFunction = true;
 
   try {
     // Step 1: Deploy the contract using cargo stylus with contract address
@@ -91,7 +88,8 @@ export default async function deployStylusContract(
 
     // Call the initialize function if orbit deployment
     if (
-      deployOptions.useInitializeFunction &&
+      !!deployOptions.isOrbit &&
+      config.chain.id !== arbitrumNitro.id &&
       contractHasInitializeFunction(contractData)
     ) {
       const publicClient = createPublicClient({

--- a/packages/stylus/scripts/deploy_contract.ts
+++ b/packages/stylus/scripts/deploy_contract.ts
@@ -5,16 +5,16 @@ import {
   extractDeploymentInfo,
   saveDeployment,
   ORBIT_CHAINS,
+  getBlockExplorerUrlFromChain,
+  getRpcUrlFromChain,
+  getContractData,
   // estimateGasPrice,
 } from "./utils/";
 import { exportStylusAbi } from "./export_abi";
 import { DeployOptions } from "./utils/type";
 import { buildDeployCommand } from "./utils/command";
-import { Chain, createPublicClient, createWalletClient, http } from "viem";
+import { Abi, createPublicClient, createWalletClient, http } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
-
-import { arbitrumNitro } from "../../nextjs/utils/scaffold-stylus/supportedChains";
-import deployedContracts from "../../nextjs/contracts/deployedContracts";
 
 /**
  * Deploy a single contract using cargo stylus
@@ -31,6 +31,9 @@ export default async function deployStylusContract(
   ensureDeploymentDirectory(config.deploymentDir);
 
   console.log(`📄 Contract name: ${config.contractName}`);
+
+  const orbitChain = ORBIT_CHAINS.find((chain) => chain.id === config.chain.id);
+  if (orbitChain) deployOptions.useInitializeFunction = true;
 
   try {
     // Step 1: Deploy the contract using cargo stylus with contract address
@@ -50,12 +53,13 @@ export default async function deployStylusContract(
     // Extract the actual deployed address from the output
     const deploymentInfo = extractDeploymentInfo(deployOutput);
     if (deploymentInfo) {
-      if (config.chain?.blockExplorerUrl) {
+      const blockExplorerUrl = getBlockExplorerUrlFromChain(config.chain);
+      if (blockExplorerUrl) {
         console.log(
-          `📋 Contract deployed: ${config.chain?.blockExplorerUrl}/address/${deploymentInfo.address}`,
+          `📋 Contract deployed: ${blockExplorerUrl}/address/${deploymentInfo.address}`,
         );
         console.log(
-          `Transaction hash: ${config.chain?.blockExplorerUrl}/tx/${deploymentInfo.txHash}`,
+          `Transaction hash: ${blockExplorerUrl}/tx/${deploymentInfo.txHash}`,
         );
       } else {
         console.log(
@@ -75,44 +79,36 @@ export default async function deployStylusContract(
       config.contractFolder,
       config.contractName,
       false,
-      config.chain?.id,
+      config.chain.id.toString(),
     );
 
     // Call the initialize function if orbit deployment
-    if (
-      !!deployOptions.isOrbit &&
-      config.chain?.id !== arbitrumNitro?.id.toString()
-    ) {
-      const orbitChain = ORBIT_CHAINS.find(
-        (chain) => chain.id.toString() === config.chain?.id,
-      );
-
-      if (!orbitChain) {
-        throw new Error(
-          `Chain ${config.chain?.id} is not supported for orbit deployment`,
-        );
-      }
-
+    if (deployOptions.useInitializeFunction) {
       const publicClient = createPublicClient({
-        chain: orbitChain as unknown as Chain,
+        chain: config.chain,
         transport: http(),
       });
 
       // need wallet client to sign the transaction
       const walletClient = createWalletClient({
-        chain: orbitChain as unknown as Chain,
+        chain: config.chain,
         transport: http(),
       });
 
       const account = privateKeyToAccount(config.privateKey as `0x${string}`);
 
+      // Get contract data from deployed contracts after ABI export
+      const contractData = getContractData(
+        config.chain.id,
+        config.contractName,
+      );
+
       const { request } = await publicClient.simulateContract({
         account,
         address: deploymentInfo.address,
-        // @ts-expect-error deployed contract is empty at the beginning
-        abi: deployedContracts[config.chain.id][config.contractName].abi,
+        abi: contractData.abi as Abi,
         functionName: "initialize",
-        args: deployOptions.constructorArgs,
+        args: deployOptions.constructorArgs as any[],
       });
 
       const initTxHash = await walletClient.writeContract(request);
@@ -124,7 +120,7 @@ export default async function deployStylusContract(
     if (deployOptions.verify) {
       try {
         const output = await executeCommand(
-          `cargo stylus verify --endpoint=${config.chain?.rpcUrl} --deployment-tx=${deploymentInfo.txHash}`,
+          `cargo stylus verify --endpoint=${getRpcUrlFromChain(config.chain)} --deployment-tx=${deploymentInfo.txHash}`,
           deployOptions.contract!,
           "Verifying contract with cargo stylus",
         );

--- a/packages/stylus/scripts/test_network.ts
+++ b/packages/stylus/scripts/test_network.ts
@@ -1,4 +1,4 @@
-import { getChain } from "./utils/";
+import { getChain, getRpcUrlFromChain } from "./utils/";
 import { SUPPORTED_NETWORKS } from "./utils/";
 
 function testNetworkFunctionality() {
@@ -9,7 +9,7 @@ function testNetworkFunctionality() {
   testNetworks.forEach((network) => {
     const chain = getChain(network);
     if (chain) {
-      console.log(`✅ ${network}: ${chain.rpcUrl}`);
+      console.log(`✅ ${network}: ${getRpcUrlFromChain(chain)}`);
     } else {
       console.log(`❌ ${network}: Not found in viem chains`);
     }

--- a/packages/stylus/scripts/utils/command.ts
+++ b/packages/stylus/scripts/utils/command.ts
@@ -27,7 +27,7 @@ export async function buildDeployCommand(
   if (
     deployOptions.constructorArgs &&
     deployOptions.constructorArgs.length > 0 &&
-    !deployOptions.useInitializeFunction
+    !deployOptions.isOrbit
   ) {
     baseCommand += ` --constructor-args ${deployOptions.constructorArgs.map((arg) => `"${arg}"`).join(" ")} `;
   }

--- a/packages/stylus/scripts/utils/command.ts
+++ b/packages/stylus/scripts/utils/command.ts
@@ -1,12 +1,13 @@
 import { spawn } from "child_process";
 import { DeploymentConfig, DeployOptions } from "./type";
 import { extractGasPriceFromOutput } from "./contract";
+import { getRpcUrlFromChain } from "./network";
 
 export async function buildDeployCommand(
   config: DeploymentConfig,
   deployOptions: DeployOptions,
 ) {
-  let baseCommand = `cargo stylus deploy --endpoint='${config.chain?.rpcUrl}' --private-key='${config.privateKey}'`;
+  let baseCommand = `cargo stylus deploy --endpoint='${getRpcUrlFromChain(config.chain)}' --private-key='${config.privateKey}'`;
 
   if (deployOptions.estimateGas) {
     return `${baseCommand} --estimate-gas`;
@@ -26,7 +27,7 @@ export async function buildDeployCommand(
   if (
     deployOptions.constructorArgs &&
     deployOptions.constructorArgs.length > 0 &&
-    !deployOptions.isOrbit
+    !deployOptions.useInitializeFunction
   ) {
     baseCommand += ` --constructor-args ${deployOptions.constructorArgs.map((arg) => `"${arg}"`).join(" ")} `;
   }
@@ -38,7 +39,7 @@ export async function estimateGasPrice(
   config: DeploymentConfig,
   deployOptions: DeployOptions,
 ): Promise<string> {
-  let deployCommand = `cargo stylus deploy --endpoint='${config.chain?.rpcUrl}' --private-key='${config.privateKey}' --no-verify --estimate-gas `;
+  let deployCommand = `cargo stylus deploy --endpoint='${getRpcUrlFromChain(config.chain)}' --private-key='${config.privateKey}' --no-verify --estimate-gas `;
   if (deployOptions.constructorArgs) {
     deployCommand += ` --constructor-args='${deployOptions.constructorArgs.join(" ")}'`;
   }

--- a/packages/stylus/scripts/utils/contract.ts
+++ b/packages/stylus/scripts/utils/contract.ts
@@ -257,10 +257,7 @@ export function loadDeployedContracts(): any {
  * @param contractName - The contract name
  * @returns The contract data with address, txHash, and abi
  */
-export function getContractData(
-  chainId: string | number,
-  contractName: string,
-): any {
+export function getContractData(chainId: string, contractName: string): any {
   const deployedContracts = loadDeployedContracts();
 
   if (
@@ -281,4 +278,8 @@ export function getContractData(
   }
 
   return contractData;
+}
+
+export function contractHasInitializeFunction(contractData: any): boolean {
+  return contractData.abi.some((abi: any) => abi.name === "initialize");
 }

--- a/packages/stylus/scripts/utils/network.ts
+++ b/packages/stylus/scripts/utils/network.ts
@@ -211,10 +211,3 @@ export function getBlockExplorerUrlFromChain(chain: Chain): string | undefined {
     chain.blockExplorers?.default?.url || chain.blockExplorers?.etherscan?.url
   );
 }
-
-// function getAliasFromNetworkName(networkName: string): string {
-//   return (
-//     Object.entries(ALIASES).find(([, alias]) => alias === networkName)?.[0] ||
-//     networkName
-//   );
-// }

--- a/packages/stylus/scripts/utils/network.ts
+++ b/packages/stylus/scripts/utils/network.ts
@@ -10,7 +10,6 @@ import {
 import * as path from "path";
 import * as fs from "fs";
 import { config as dotenvConfig } from "dotenv";
-import { SupportedNetworkMinimal } from "./type";
 
 const envPath = path.resolve(__dirname, "../../.env");
 if (fs.existsSync(envPath)) {
@@ -47,7 +46,7 @@ export const ORBIT_CHAINS: Chain[] = [
   superpositionTestnet as Chain,
 ];
 
-export function getChain(networkName: string): SupportedNetworkMinimal | null {
+export function getChain(networkName: string): Chain | null {
   try {
     const actualNetworkName = ALIASES[networkName.toLowerCase()] || networkName;
 
@@ -55,15 +54,7 @@ export function getChain(networkName: string): SupportedNetworkMinimal | null {
       ([key]) => key.toLowerCase() === actualNetworkName.toLowerCase(),
     );
 
-    if (chainEntry) {
-      return {
-        name: chainEntry[0],
-        alias: getAliasFromNetworkName(chainEntry[0]),
-        id: chainEntry[1].id.toString(),
-        rpcUrl: getRpcUrlFromChain(chainEntry[1]),
-        blockExplorerUrl: chainEntry[1].blockExplorers?.default?.url,
-      };
-    }
+    if (chainEntry) return chainEntry[1];
 
     const supportedNetworks = Object.keys(SUPPORTED_NETWORKS);
     console.warn(
@@ -132,6 +123,7 @@ export function getPrivateKey(networkName: string): string {
 
 export const getAccountAddress = (networkName: string): Address | undefined => {
   const actualNetworkName = ALIASES[networkName.toLowerCase()] || networkName;
+
   switch (actualNetworkName.toLowerCase()) {
     case "arbitrum":
       return process.env["ACCOUNT_ADDRESS_MAINNET"] as Address;
@@ -155,7 +147,7 @@ export const getAccountAddress = (networkName: string): Address | undefined => {
   }
 };
 
-function getRpcUrlFromChain(chain: Chain): string {
+export function getRpcUrlFromChain(chain: Chain): string {
   //Prefer user rpc url from env
   switch (chain.id) {
     case arbitrum.id:
@@ -214,9 +206,15 @@ function getRpcUrlFromChain(chain: Chain): string {
   throw new Error(`No RPC URL found for chain ${chain.name}`);
 }
 
-function getAliasFromNetworkName(networkName: string): string {
+export function getBlockExplorerUrlFromChain(chain: Chain): string | undefined {
   return (
-    Object.entries(ALIASES).find(([, alias]) => alias === networkName)?.[0] ||
-    networkName
+    chain.blockExplorers?.default?.url || chain.blockExplorers?.etherscan?.url
   );
 }
+
+// function getAliasFromNetworkName(networkName: string): string {
+//   return (
+//     Object.entries(ALIASES).find(([, alias]) => alias === networkName)?.[0] ||
+//     networkName
+//   );
+// }

--- a/packages/stylus/scripts/utils/type.ts
+++ b/packages/stylus/scripts/utils/type.ts
@@ -1,4 +1,4 @@
-import { Address } from "viem";
+import { Address, Chain } from "viem";
 
 interface BaseCommandOptions {
   _: (string | number)[];
@@ -14,11 +14,11 @@ export interface DeployOptions {
   contract?: string;
   name?: string;
   constructorArgs?: NonNullable<unknown>[];
+  useInitializeFunction?: boolean;
   network?: string;
   estimateGas?: boolean;
   maxFee?: string;
   verify?: boolean;
-  isOrbit?: boolean;
 }
 
 export interface DeploymentData {
@@ -32,7 +32,7 @@ export interface DeploymentConfig {
   contractFolder: string;
   contractName: string;
   deploymentDir: string;
-  chain?: SupportedNetworkMinimal;
+  chain: Chain;
 }
 
 export interface ExportConfig {
@@ -42,12 +42,4 @@ export interface ExportConfig {
   contractAddress: Address;
   txHash: string;
   chainId: string;
-}
-
-export interface SupportedNetworkMinimal {
-  name: string;
-  alias: string;
-  id: string;
-  rpcUrl: string;
-  blockExplorerUrl?: string | undefined;
 }

--- a/packages/stylus/scripts/utils/type.ts
+++ b/packages/stylus/scripts/utils/type.ts
@@ -14,7 +14,7 @@ export interface DeployOptions {
   contract?: string;
   name?: string;
   constructorArgs?: NonNullable<unknown>[];
-  useInitializeFunction?: boolean;
+  isOrbit?: boolean;
   network?: string;
   estimateGas?: boolean;
   maxFee?: string;

--- a/readme.md
+++ b/readme.md
@@ -233,9 +233,10 @@ Check full documentation for more [details](https://docs.arbitrum.io/stylus/how-
 
 ### Stylus Local Verification (Under Development)
 
-Make sure your constructor does not contain any args
+Make sure your contract does not include constructor or constructor does not contain any args
 
 ```rs
+[#constructor]
 pub fn constructor(&mut self)
 ```
 
@@ -276,6 +277,8 @@ For public verification on Arbiscan, follow these steps:
 Check official document for detail instructions: <https://docs.arbitrum.io/stylus/how-tos/verifying-contracts-arbiscan>
 
 > **Note**: Arbiscan verification for Stylus contracts is still evolving. If you encounter issues, consider using the local verification method or check Arbiscan's latest documentation for Stylus-specific instructions.
+
+**Tip**: If you still want to initialize your contract, then add your own `initialize()` function and initialize it yourself
 
 </details>
 

--- a/readme.md
+++ b/readme.md
@@ -279,6 +279,21 @@ Check official document for detail instructions: <https://docs.arbitrum.io/stylu
 > **Note**: Arbiscan verification for Stylus contracts is still evolving. If you encounter issues, consider using the local verification method or check Arbiscan's latest documentation for Stylus-specific instructions.
 
 **Tip**: If you still want to initialize your contract, then add your own `initialize()` function and initialize it yourself
+Sample :
+
+```
+pub fn initialize(&mut self, initial_number: U256) {
+   if !self.is_initialized.get() {
+      self.number.set(initial_number);
+      self.is_initialized.set(true);
+   } else {
+      panic!("Counter already initialized");
+   }
+}
+```
+
+Then use `cast --rpc-url <your-rpc-url> --private-key <your-private-key> [deployed-contract-address] "initialize(uint256)" <initial_number>`
+Or check [`deploy_contract.ts` lines 95-118](packages/stylus/scripts/deploy_contract.ts#L95-L118) and add it to your `deploy.ts` script.
 
 </details>
 


### PR DESCRIPTION
## Description:
Try to enhance deployment flow with orbit chain:

- Fixed error `contract not found for first time deployed`: Dynamically read deployedContract to reload it after we write contract abi into
- Fixed calling initialization while contract not included causing crash : Skip `initialization` it's not found in contract

**A note:** can ambiguously use isOrbit while deploying to  any chain to pass `constructor args` to `initilize()` function
