### PR TITLE
chore: update workflow to sync develop branch with bulletproof-contracts for E2E tests

### DIFF
--- a/.github/workflows/sync-bulletproof-contracts.yaml
+++ b/.github/workflows/sync-bulletproof-contracts.yaml
@@ -1,9 +1,9 @@
-name: Sync Main to bulletproof-contracts for E2E Tests
+name: Sync Develop to bulletproof-contracts for E2E Tests
 
 on:
   push:
     branches:
-      - main
+      - develop
 
 jobs:
   sync-and-update:
@@ -13,11 +13,11 @@ jobs:
       contents: write
 
     steps:
-      - name: Checkout main branch
+      - name: Checkout develop branch
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: main
+          ref: develop
 
       - name: Configure Git
         run: |
@@ -29,9 +29,9 @@ jobs:
           git fetch origin
           git checkout bulletproof-contracts
 
-      - name: Merge main into bulletproof-contracts
+      - name: Merge develop into bulletproof-contracts
         run: |
-          git merge -X theirs main --no-edit || echo "No changes to merge"
+          git merge -X theirs develop --no-edit || echo "No changes to merge"
 
       - name: Add deploy bulletproof contracts to deploy script
         run: |


### PR DESCRIPTION
## Description

Update workflow to sync develop branch with bulletproof-contracts for E2E tests

## Additional Information

- [ ] I have read the [contributing docs](/Arb-Stylus/scaffold-stylus/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [ ] This is not a duplicate of any [existing pull request](https://github.com/Arb-Stylus/scaffold-stylus/pulls)

## Related Issues

_Closes #{issue number}_

_Note: bulletproof should be synced with develop instead of main because It's used to debug so we could test with develop first
