### PR TITLE
fix: local faucet

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Faucet.tsx
+++ b/packages/nextjs/components/scaffold-eth/Faucet.tsx
@@ -72,7 +72,6 @@ export const Faucet = () => {
       await faucetTxn({
         to: inputAddress,
         value: parseEther(sendValue as `${number}`),
-        account: faucetAddress,
       });
       setLoading(false);
       setInputAddress(undefined);

--- a/packages/nextjs/components/scaffold-eth/FaucetButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/FaucetButton.tsx
@@ -36,7 +36,6 @@ export const FaucetButton = () => {
     try {
       setLoading(true);
       await faucetTxn({
-        account: FAUCET_ADDRESS,
         to: address,
         value: parseEther(NUM_OF_ETH),
       });


### PR DESCRIPTION
## Description

Removed the account parameter from the transaction. The wallet client will use its configured account (from privateKeyToAccount) to sign the transaction locally.

## Additional Information

- [ ] I have read the [contributing docs](/Arb-Stylus/scaffold-stylus/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [ ] This is not a duplicate of any [existing pull request](https://github.com/Arb-Stylus/scaffold-stylus/pulls)

