### PR TITLE
Fix hidden Read methods with no parameters

### DIFF
--- a/packages/nextjs/app/debug/_components/contract/ContractReadMethods.tsx
+++ b/packages/nextjs/app/debug/_components/contract/ContractReadMethods.tsx
@@ -11,9 +11,9 @@ export const ContractReadMethods = ({ deployedContractData }: { deployedContract
     ((deployedContractData.abi || []) as Abi).filter(part => part.type === "function") as AbiFunction[]
   )
     .filter(fn => {
-      const isQueryableWithParams =
-        (fn.stateMutability === "view" || fn.stateMutability === "pure") && fn.inputs.length > 0;
-      return isQueryableWithParams;
+      const isQueryable =
+        (fn.stateMutability === "view" || fn.stateMutability === "pure");
+      return isQueryable;
     })
     .map(fn => {
       return {


### PR DESCRIPTION
The filter condition `fn.inputs.length > 0` was preventing functions that take no arguments (e.g., simple getters like `totalSupply()`) from being displayed in the Read methods UI. This PR removes that restriction, allowing all view/pure functions to be listed.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.