### PR TITLE
fix(ui): repair dropdowns broken by DaisyUI v5 upgrade

### DIFF
--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -105,9 +105,8 @@ export const Header = () => {
       }}
     >
       <div className="navbar-start w-auto lg:w-1/2">
-        <div className="lg:hidden dropdown" ref={burgerMenuRef}>
+        <div className={`lg:hidden dropdown ${isDrawerOpen ? "dropdown-open" : ""}`} ref={burgerMenuRef}>
           <label
-            tabIndex={0}
             className={`ml-1 btn btn-ghost ${isDrawerOpen ? "hover:bg-secondary" : "hover:bg-transparent"}`}
             onClick={() => {
               setIsDrawerOpen(prevIsOpenState => !prevIsOpenState);

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/AddressInfoDropdown.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/AddressInfoDropdown.tsx
@@ -40,21 +40,22 @@ export const AddressInfoDropdown = ({ address, ensAvatar, displayName, onSwitchA
   const { copyToClipboard: copyAddressToClipboard, isCopiedToClipboard: isAddressCopiedToClipboard } =
     useCopyToClipboard();
   const [selectingNetwork, setSelectingNetwork] = useState(false);
-  const dropdownRef = useRef<HTMLDetailsElement>(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
 
   const closeDropdown = () => {
     setSelectingNetwork(false);
-    dropdownRef.current?.removeAttribute("open");
+    setIsOpen(false);
   };
 
   useOutsideClick(dropdownRef, closeDropdown);
 
   return (
     <>
-      <details ref={dropdownRef} className="dropdown dropdown-end leading-3">
-        <summary
-          tabIndex={0}
+      <div ref={dropdownRef} className={`dropdown dropdown-end leading-3 ${isOpen ? "dropdown-open" : ""}`}>
+        <label
           className="dropdown-toggle gap-0 !h-auto"
+          onClick={() => setIsOpen(prev => !prev)}
           style={{
             position: "relative",
             width: "220px",
@@ -126,7 +127,7 @@ export const AddressInfoDropdown = ({ address, ensAvatar, displayName, onSwitchA
               }}
             />
           </div>
-        </summary>
+        </label>
         <ul
           tabIndex={0}
           className="dropdown-content menu z-[2] p-2 mt-4 gap-1"
@@ -229,7 +230,7 @@ export const AddressInfoDropdown = ({ address, ensAvatar, displayName, onSwitchA
             </button>
           </li>
         </ul>
-      </details>
+      </div>
     </>
   );
 };

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/WrongNetworkDropdown.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/WrongNetworkDropdown.tsx
@@ -1,13 +1,19 @@
+import { useRef, useState } from "react";
 import { NetworkOptions } from "./NetworkOptions";
 import { useDisconnect } from "wagmi";
 import { ArrowLeftEndOnRectangleIcon, ChevronDownIcon } from "@heroicons/react/24/outline";
+import { useOutsideClick } from "~~/hooks/scaffold-eth";
 
 export const WrongNetworkDropdown = () => {
   const { disconnect } = useDisconnect();
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useOutsideClick(dropdownRef, () => setIsOpen(false));
 
   return (
-    <div className="dropdown dropdown-end mr-2">
-      <label tabIndex={0} className="btn btn-error btn-sm dropdown-toggle gap-1">
+    <div ref={dropdownRef} className={`dropdown dropdown-end mr-2 ${isOpen ? "dropdown-open" : ""}`}>
+      <label className="btn btn-error btn-sm dropdown-toggle gap-1" onClick={() => setIsOpen(prev => !prev)}>
         <span>Wrong network</span>
         <ChevronDownIcon className="h-6 w-4 ml-2 sm:ml-0" />
       </label>


### PR DESCRIPTION
## Summary

Follow-up fix on top of #67. The SE-2 parity bump (Tailwind v4 + **DaisyUI v5**) silently broke every dropdown in the app — the menus toggle in the DOM but render **invisible**, so clicking the address chip / wrong-network button / mobile burger does nothing. This isn't caught by typecheck/lint/build; it only shows up in manual QA (the visual-QA risk flagged in #67).

## Root cause

DaisyUI v5 reworked the `dropdown` component. The generated CSS now sets:

```css
.dropdown .dropdown-content { opacity: 0; scale: .95 }   /* hidden by default */
```

and only reveals the content when the `.dropdown` has `.dropdown-open`, `:focus-within`, or `:hover`. The native `<details open>` attribute is **no longer** a visibility trigger (it was in v4). The existing components were never updated (untouched by #67), so:

- `AddressInfoDropdown` — used `<details>/<summary>` → opened natively but stayed at `opacity:0`
- `WrongNetworkDropdown` — used the `:focus` method → fragile under v5
- `Header` (mobile nav) — state-driven but missing the `dropdown-open` class

## Fix

Switch all three to a **React-controlled open state** that toggles the `dropdown-open` class, removing any reliance on `[open]` / `:focus-within`:

- `AddressInfoDropdown`: `<details>/<summary>` → `<div>/<label>` + `isOpen` state (ref retyped to `HTMLDivElement`)
- `WrongNetworkDropdown`: focus-method → controlled `isOpen` + `useOutsideClick`
- `Header`: add `dropdown-open` to the existing `isDrawerOpen` drawer

Trigger `tabIndex` dropped where present so the `:focus-within` path doesn't fight the controlled state (DaisyUI sets `pointer-events:none` on the focused first child, which would swallow the toggle-to-close click).

## Verification

- ✅ typecheck clean
- ✅ lint 0 errors
- ✅ build 7/7 pages (Turbopack)
- ✅ manual: address dropdown, switch-network submenu, reveal-PK / disconnect, and mobile burger all open & close correctly
