### PR TITLE
fix(stylus): buffer deploy max-fee to prevent -32000 underpricing

### DIFF
--- a/packages/stylus/scripts/utils/command.ts
+++ b/packages/stylus/scripts/utils/command.ts
@@ -5,6 +5,38 @@ import {
   isContractHasConstructor,
 } from "./contract";
 import { getRpcUrlFromChain } from "./network";
+import { createPublicClient, http, formatUnits } from "viem";
+
+const DEFAULT_GAS_FEE_MULTIPLIER = 3;
+const MIN_FEE_GWEI = 0.1;
+
+function getGasFeeMultiplier(): number {
+  const envVal = process.env["DEPLOY_GAS_FEE_MULTIPLIER"];
+  if (envVal) {
+    const parsed = parseFloat(envVal);
+    if (!isNaN(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return DEFAULT_GAS_FEE_MULTIPLIER;
+}
+
+async function getBufferedMaxFeeGwei(rpcUrl: string): Promise<number> {
+  try {
+    const publicClient = createPublicClient({
+      transport: http(rpcUrl),
+    });
+    const block = await publicClient.getBlock({ blockTag: "latest" });
+    if (block.baseFeePerGas === null) {
+      return MIN_FEE_GWEI;
+    }
+    const baseFeeGwei = Number(formatUnits(block.baseFeePerGas, 9));
+    const buffered = baseFeeGwei * getGasFeeMultiplier();
+    return Math.max(buffered, MIN_FEE_GWEI);
+  } catch {
+    return MIN_FEE_GWEI;
+  }
+}
 
 export async function buildDeployCommand(
   config: DeploymentConfig,
@@ -18,6 +50,12 @@ export async function buildDeployCommand(
 
   if (deployOptions.maxFee) {
     baseCommand += ` --max-fee-per-gas-gwei=${deployOptions.maxFee}`;
+  } else {
+    // maxFeePerGas is a CEILING (actual charge = base fee), so over-provisioning is safe and free.
+    // Cargo stylus without this flag uses a tight estimate that the base fee can creep past.
+    const rpcUrl = getRpcUrlFromChain(config.chain);
+    const maxFeeGwei = await getBufferedMaxFeeGwei(rpcUrl);
+    baseCommand += ` --max-fee-per-gas-gwei=${maxFeeGwei}`;
   }
 
   if (!deployOptions.verify) {


### PR DESCRIPTION
The release pipeline (demo.yaml: `yarn deploy --network sepolia`) hit error -32000 max fee per gas less than block base fee (maxFeePerGas 20020000 vs baseFee 20024000). `buildDeployCommand` omitted `--max-fee-per-gas-gwei` when no explicit maxFee was passed, so cargo stylus used a tight estimate the base fee crept past. This computes a buffered ceiling (base fee * 3, min floor 0.1 gwei) from the live base fee, mirroring the frontend gasFeeMultiplier fix (#68). maxFeePerGas is a ceiling so over-provisioning is free. Explicit `--max-fee` still overrides; estimate-gas path unchanged.