### PR TITLE
fix(stylus): pin parity-scale-codec =3.7.5 to prevent transitive lock drift

### DIFF
--- a/packages/stylus/contracts/Cargo.lock
+++ b/packages/stylus/contracts/Cargo.lock
@@ -5613,6 +5613,7 @@ dependencies = [
  "eyre",
  "hex",
  "openzeppelin-stylus",
+ "parity-scale-codec",
  "stylus-sdk",
  "tokio",
 ]

--- a/packages/stylus/contracts/your-contract/Cargo.toml
+++ b/packages/stylus/contracts/your-contract/Cargo.toml
@@ -13,6 +13,7 @@ alloy-primitives = "=0.8.20"
 alloy-sol-types = "=0.8.20"
 stylus-sdk = "0.9.0"
 hex = { version = "0.4", default-features = false }
+parity-scale-codec = "=3.7.5"
 openzeppelin-stylus = "0.3.0"
 
 [dev-dependencies]


### PR DESCRIPTION
## ⚠️ DO NOT MERGE before create-stylus `q3le-94` lands

Merging to `main` triggers `release-create-stylus.yaml`, which rsyncs this repo into create-stylus/templates/base **and auto-publishes** create-stylus. The CLI-side fix (create-stylus PR for branch `alan/q3le-94-fix-create-stylus`) **must merge first**, or the publish ships a new template with stale CLI logic. Open here for review only.

## Why

`parity-scale-codec` was held at 3.7.5 **only** by the committed `Cargo.lock` — no `=` pin existed in any `Cargo.toml`. A full lock re-resolve can drift it, which is exactly what broke CI in #77 (3.7.5 → 3.6.12, scale-info `Encode` derive failure). The extension scaffolding fix regenerates the workspace lock when an extension adds a member, so pinning the crate makes any such regeneration **drift-proof**.

## Change
- `your-contract/Cargo.toml`: add explicit `parity-scale-codec = "=3.7.5"` (makes the existing transitive edge explicit + exact-pinned).
- `Cargo.lock`: minimal, pin-preserving update (+1 dependency-list line; zero version bumps).

## Verification
- Scratch regen (delete lock, full `cargo generate-lockfile` in a throwaway copy): parity-scale-codec stays **3.7.5**.
- End-to-end via create-stylus: scaffolding `-e erc-20` and base both produce locks with `parity-scale-codec=3.7.5`; `cargo metadata --locked` resolves cleanly.

## Context
Part 3 of a 4-part cross-repo fix for the extension deploy lock-staleness bug (companion: create-stylus lock-refresh #2, per-member lock cleanup #4 already merged, and a CI smoke test #1).