### PR TITLE
fix(devnode): bump nitro v3.11.0 + schedule ArbOS 60 upgrade so >24KB multi-fragment Stylus contracts activate on the local devnode

### DIFF
--- a/nitro-devnode/run-dev-node.sh
+++ b/nitro-devnode/run-dev-node.sh
@@ -70,6 +70,18 @@ cast send 0x00000000000000000000000000000000000000FF "becomeChainOwner()" \
   --private-key $PRIVATE_KEY \
   --rpc-url $RPC
 
+# Upgrade ArbOS to version 60 to enable multi-fragment Stylus activation.
+# Nitro v3.10.0+ / ArbOS 60 introduced activation of contracts whose compressed
+# wasm exceeds the 24KB single-fragment limit (e.g. full ERC-20/ERC-721 templates).
+# The dev node boots at ArbOS 59 (ArbSys.arbOSVersion() reports 114); without this
+# upgrade, activateProgram reverts ("execution reverted") for multi-fragment (>24KB)
+# contracts even on the v3.11.0 image. The argument is the ArbOS version (60), NOT the
+# ArbSys-reported number (115). Timestamp 0 applies the upgrade on the next mined block
+# (the setL1PricePerUnit call below), after which ArbSys.arbOSVersion() reports 115.
+echo "Upgrading ArbOS to version 60 for multi-fragment (>24KB) Stylus support..."
+cast send -r $RPC --private-key $PRIVATE_KEY 0x0000000000000000000000000000000000000070 \
+  'scheduleArbOSUpgrade(uint64,uint64)' 60 0
+
 # Set the L1 data fee to 0 so it doesn't impact the L2 Gas limit.
 # This makes the gas estimates closer to Ethereum and allows the deployment of the CREATE2 factory
 cast send -r $RPC --private-key $PRIVATE_KEY 0x0000000000000000000000000000000000000070 'setL1PricePerUnit(uint256)' 0x0

--- a/nitro-devnode/run-dev-node.sh
+++ b/nitro-devnode/run-dev-node.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-NITRO_NODE_VERSION="v3.5.5-90ee45c"  # <-- only update this when you need a new version
+NITRO_NODE_VERSION="v3.11.0-a618155"  # <-- only update this when you need a new version
 TARGET_IMAGE="offchainlabs/nitro-node:${NITRO_NODE_VERSION}"
 
 RPC=http://127.0.0.1:8547

--- a/nitro-devnode/start-chain-with-cors.sh
+++ b/nitro-devnode/start-chain-with-cors.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-NITRO_NODE_VERSION="v3.5.5-90ee45c"
+NITRO_NODE_VERSION="v3.11.0-a618155"
 TARGET_IMAGE="offchainlabs/nitro-node:${NITRO_NODE_VERSION}"
 
 RPC=http://127.0.0.1:8547

--- a/nitro-devnode/start-chain-with-cors.sh
+++ b/nitro-devnode/start-chain-with-cors.sh
@@ -78,6 +78,18 @@ cast send 0x00000000000000000000000000000000000000FF "becomeChainOwner()" \
   --private-key $PRIVATE_KEY \
   --rpc-url $RPC
 
+# Upgrade ArbOS to version 60 to enable multi-fragment Stylus activation.
+# Nitro v3.10.0+ / ArbOS 60 introduced activation of contracts whose compressed
+# wasm exceeds the 24KB single-fragment limit (e.g. full ERC-20/ERC-721 templates).
+# The dev node boots at ArbOS 59 (ArbSys.arbOSVersion() reports 114); without this
+# upgrade, activateProgram reverts ("execution reverted") for multi-fragment (>24KB)
+# contracts even on the v3.11.0 image. The argument is the ArbOS version (60), NOT the
+# ArbSys-reported number (115). Timestamp 0 applies the upgrade on the next mined block
+# (the setL1PricePerUnit call below), after which ArbSys.arbOSVersion() reports 115.
+echo "Upgrading ArbOS to version 60 for multi-fragment (>24KB) Stylus support..."
+cast send -r $RPC --private-key $PRIVATE_KEY 0x0000000000000000000000000000000000000070 \
+  'scheduleArbOSUpgrade(uint64,uint64)' 60 0
+
 # Set the L1 data fee to 0 so it doesn't impact the L2 Gas limit.
 # This makes the gas estimates closer to Ethereum and allows the deployment of the CREATE2 factory
 cast send -r $RPC --private-key $PRIVATE_KEY 0x0000000000000000000000000000000000000070 'setL1PricePerUnit(uint256)' 0x0


### PR DESCRIPTION
## Problem

`npx create-stylus@latest -e erc-20` scaffolds and compiles fine, but deploying `erc20-example` to the local nitro devnode (`yarn chain`) fails with:

```
error: server returned an error response: error code -32000: execution reverted
```

The node logs `Served eth_call err="execution reverted"`.

## Root cause — multi-fragment (>24KB) activation, **not** the constructor/StylusDeployer

cargo-stylus 0.10.2 runs a pre-flight `eth_call` to **`ArbWasm.activateProgram(address)`** (precompile `0x71`, selector `0x58c780c2`) with state overrides injecting the program code, **before sending any tx**. The deploy aborts here — so there is no tx hash to trace; the failure is the simulated activation reverting.

The reverting variable is **contract size crossing the EIP-170 24576-byte (24 KB) limit**. Above it, stylus-tools splits the program into **N ≥ 2 fragments** at separate addresses, fronted by a `0xeff002…` multi-fragment dispatcher header. Multi-fragment Stylus activation is an **ArbOS-version-gated capability**: it was introduced in **ArbOS 60** (shipped in nitro **v3.10.0+**). ArbOS 59 and earlier cannot activate the multi-fragment layout and revert.

### Evidence (same toolchain, same node)

| Contract | On-chain size | Fragments | `activateProgram` eth_call | Deploy |
|---|---|---|---|---|
| `your-contract` (**has `#[constructor]`**) | 20846 B (20.8 KB) | 1 | ✅ succeeds | ✅ |
| `erc20-example` (**has `#[constructor]`**) | 25147 B (25.1 KB) | **2** | ❌ reverts on ArbOS 59 | ❌ |

- **Constructor ruled out:** `your-contract` *also* has a `#[constructor]` and deploys fine. Deploying `erc20-example` **without** `--constructor-args` (direct CREATE, bypassing the StylusDeployer) **still reverts at the same `activateProgram` call**. The StylusDeployer is not involved in the revert.

## Fix — TWO parts, both required

The image bump **alone is not sufficient**. The nitro dev node ships ArbOS 60 capability in v3.10.0+, but **dev mode boots at ArbOS 59 and stays there** (`InitialArbOSVersion: 59` in the dev genesis; `ArbSys.arbOSVersion()` reports `114` = 55 + 59). So even on v3.11.0, multi-fragment activation still reverts until the chain is actually moved to ArbOS 60.

Applied to **both** vendored scripts (`nitro-devnode/start-chain-with-cors.sh`, which `yarn chain` runs, and `nitro-devnode/run-dev-node.sh`):

1. **Bump the pinned image** `v3.5.5-90ee45c → v3.11.0-a618155` (ships the ArbOS 60 multi-fragment activation machinery).
2. **Schedule the ArbOS 60 upgrade** right after `becomeChainOwner()`, before any contract deploy:

   ```bash
   cast send -r $RPC --private-key $PRIVATE_KEY 0x0000000000000000000000000000000000000070 \
     'scheduleArbOSUpgrade(uint64,uint64)' 60 0
   ```

   `ArbOwner.scheduleArbOSUpgrade(uint64 newVersion, uint64 timestamp)` (precompile `0x70`, selector `0xe388b381`). **The argument is the ArbOS version `60`, NOT the ArbSys-reported number `115`** — a prior attempt passed `115` and it was silently ignored (out of range). `timestamp 0` applies the upgrade on the next mined block (the `setL1PricePerUnit` call immediately following), after which `ArbSys.arbOSVersion()` reports `115` (= 55 + 60).

`nitro-devnode` is **vendored** here (regular committed files; `.gitmodules` is empty), so this edit is the complete scaffold-stylus fix — no submodule/upstream PR needed.

## Verification (local devnode, ArbOS 60)

**(a) A/B proof of the capability gate** — same synthetic 29.4 KB / **2-fragment** contract, same v3.11.0 node, `cargo stylus check` (the `activateProgram` eth_call):

| Node state | `ArbSys.arbOSVersion()` | activation result |
|---|---|---|
| Boot, no upgrade (**ArbOS 59**) | 114 | ❌ `execution reverted` |
| After `scheduleArbOSUpgrade(60, 0)` (**ArbOS 60**) | 115 | ✅ activates (wasm data fee computed) |

**(b) Synthetic 2-fragment full deploy** (ArbOS 60): deployed `0x408da76e87511429485c32e4ad647dd14823fdc4`, activation tx `0xaf85fd7f1664f95a9e5b1c64cab7d76a1ace26bbfb15292beadee55a4934035d` — **status 1**; live method call returns expected value.

**(c) Literal `erc20-example` (25.1 KB / 2 fragments) on the local node started by the fixed `start-chain-with-cors.sh`** — `ArbSys.arbOSVersion()` confirmed `115` before deploy:

- **Contract:** `0xab8e440727a38bbb180f7032ca4a8009e7b52b80`
- **Deploy/activate tx:** `0xdf7d0a7c56eb62060902a704a84ec327655df24b7dcb220df1dcd3e794b2dc04` — **status 1**
- Constructor ran; live reads: `name() = "ScaffoldToken"`, `symbol() = "SCA"`, `cap() = 1000000000000000000000000`

This proves `erc20-example`, `erc-721`, and all future >24KB multi-fragment contracts now activate + deploy on the local devnode.

The full devnode setup runs clean on v3.11.0 (chain owner, ArbOS 60 upgrade, CREATE2 factory, Cache Manager deploy + registration, StylusDeployer deploy, account funding all succeed).

## create-stylus propagation (automatic)

create-stylus also **vendors** `nitro-devnode` under `templates/base/`. The sync workflow `release-create-stylus.yaml` runs `rsync -av --delete source_repo/ → destination_repo/templates/base` on merge to `main`, and `nitro-devnode/` is **not** in its exclude list. So merging this PR auto-copies both bumped+patched scripts into create-stylus and republishes — `npx create-stylus -e erc-20` then ships the complete fix. No manual change in create-stylus.
