### PR TITLE
fix: pin Dockerfile cargo-stylus and add devnode cleanup

### DIFF
--- a/nitro-devnode/run-dev-node.sh
+++ b/nitro-devnode/run-dev-node.sh
@@ -37,6 +37,7 @@ fi
 
 # Start Nitro dev node in the background
 echo "Starting Nitro dev node..."
+docker rm -f nitro-dev >/dev/null 2>&1 || true
 docker run --rm --name nitro-dev -p 8547:8547 "${TARGET_IMAGE}" --dev --http.addr 0.0.0.0 --http.api=net,web3,eth,debug &
 
 # Kill background processes when exiting

--- a/nitro-devnode/stylus-dev/Dockerfile
+++ b/nitro-devnode/stylus-dev/Dockerfile
@@ -7,4 +7,4 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --de
 ENV PATH="/root/.cargo/bin:${PATH}"
 RUN curl -L https://foundry.paradigm.xyz | bash && . ~/.bashrc && ~/.foundry/bin/foundryup
 ENV PATH="/root/.foundry/bin:${PATH}"
-RUN cargo install --force cargo-stylus
+RUN cargo install --force --locked cargo-stylus@0.10.2


### PR DESCRIPTION
Reduces the scope of this PR to fix the nitro-devnode cleanup script and to pin cargo-stylus in the Docker image. 

The originally attempted `cargo-stylus` 0.10.8 bump has been reverted. It requires `rustc >= 1.91.0`, which breaks CI because `packages/stylus/contracts/rust-toolchain.toml` is pinned to `1.89.0`. Every version of cargo-stylus from 0.10.3 onward requires `rustc 1.91.0`. A future bump will need to bump the rust toolchain and cargo-stylus together.

We DO still pin `cargo-stylus@0.10.2` in the devnode Dockerfile instead of leaving it unpinned (so it doesn't silently break on `rustc 1.89`).