### PR TITLE
chore: gitignore agent artifacts

### DIFF
--- a/.github/workflows/release-create-stylus.yaml
+++ b/.github/workflows/release-create-stylus.yaml
@@ -87,6 +87,8 @@ jobs:
             --exclude='__test*__' \
             --exclude='CHANGELOG*' \
             --exclude='CONTRIBUTING*' \
+            --exclude='.claude/' \
+            --exclude='.worktrees/' \
             source_repo/ destination_repo/templates/base
           cd destination_repo
           git add .

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,9 @@ node_modules
 !.vscode/settings.json
 .idea
 .vercel
+
+# Agent tooling and artifacts
+.claude/*
+!.claude/workflows/
+!.claude/skills/
+.worktrees/


### PR DESCRIPTION
Harden the repo against leaking local agent-tooling files into the public repo and the create-stylus npm package.

### Context - the exposure chain
1. public repo -> 
2. create-stylus template -> 
3. npm -> 
4. scaffolded onto every user's disk running 'npx create-stylus'

### Why both changes are needed
1. **.gitignore**: This is the primary barrier. The GitHub Actions 'checkout' step only clones tracked files. By ignoring these files, we ensure they are never tracked in the source repository and thus never downloaded during the checkout step.
2. **rsync --exclude**: This is a defense-in-depth measure. Since the workflow has a step that rewrites '.gitignore' to '.gitignore.template.mjs' (and deletes the original), '.gitignore' rules are inactive during rsync. If a file is mistakenly tracked or the workflow changes in the future, these explicit excludes guarantee the artifacts aren't copied into the 'create-stylus' template and published to NPM.