### PR TITLE
chore: Dependency Hygiene

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,15 +8,6 @@
       "packages/nextjs"
     ]
   },
-  "overrides": {
-    "chalk": "5.3.0",
-    "strip-ansi": "7.1.0",
-    "color-convert": "2.0.1",
-    "color-name": "1.1.4",
-    "is-core-module": "2.13.1",
-    "error-ex": "1.3.2",
-    "has-ansi": "5.0.1"
-  },
   "scripts": {
     "account": "yarn workspace @ss/stylus account",
     "chain": "./nitro-devnode/start-chain-with-cors.sh",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -13,15 +13,6 @@
     "vercel": "vercel",
     "vercel:yolo": "vercel --build-env NEXT_PUBLIC_IGNORE_BUILD_ERROR=true"
   },
-  "overrides": {
-    "chalk": "5.3.0",
-    "strip-ansi": "7.1.0",
-    "color-convert": "2.0.1",
-    "color-name": "1.1.4",
-    "is-core-module": "2.13.1",
-    "error-ex": "1.3.2",
-    "has-ansi": "5.0.1"
-  },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
     "@rainbow-me/rainbowkit": "2.2.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16624,9 +16624,14 @@ __metadata:
   linkType: hard
 
 "preact@npm:^10.16.0":
-  version: 10.27.1
-  resolution: "preact@npm:10.27.1"
-  checksum: 57a34d9c2f0454bb87bf0f07563a0a4b13d9f1d1f00bb981a043946eb09e8c3e00fff649e59e5b6a87cb686055890313c74c56851a7dbecf47cb126ac6a08206
+  version: 10.29.7
+  resolution: "preact@npm:10.29.7"
+  peerDependencies:
+    preact-render-to-string: ">=5"
+  peerDependenciesMeta:
+    preact-render-to-string:
+      optional: true
+  checksum: b972cfff63baaecca86440abb7f6fd27cb73b108efa8f055244b449cbf611b5105a3a0335fc57f05c51b4b5712e8a3f1b2fa61e7451f69d6bbbb2f6ed353ec92
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR fixes two dependency hygiene issues:

1. **preact security bump** (GHSA-36hm-qxxp-pg3m)
   - Before: `preact` resolved to `10.27.1` in `yarn.lock`
   - After: `preact` resolves to `10.29.7` in `yarn.lock` (satisfying the fix in 10.27.3+)
   - This was done as a lockfile-only change since the existing range `^10.16.0` already allowed it.

2. **Cleaned up unused `overrides` block**
   - Deleted the dead `overrides` block in the root `package.json` and `packages/nextjs/package.json`. 
   - Since this repo uses yarn@3.2.3 (Berry), it uses `resolutions` instead of npm's `overrides`. The `overrides` block was never applying, which is evident since `yarn.lock` resolved `chalk` to versions 5.6.2 and 4.1.2 alongside the pinned 5.3.0.
   - The blocks were deleted rather than renamed to `resolutions`, because renaming them would have applied force-deduplication to 7 packages and mutated the lockfile unnecessarily. There is no live exposure (chalk 5.6.2 is a clean republish).