### PR TITLE
chore: bump @types/node to ^24 in nextjs workspace

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.4",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
-    "@types/node": "^18.19.130",
+    "@types/node": "^24",
     "@types/react": "^19.2.14",
     "abitype": "1.0.6",
     "bgipfs": "^0.0.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6206,7 +6206,7 @@ __metadata:
     "@tailwindcss/postcss": ^4.2.4
     "@tanstack/react-query": ^5.59.15
     "@trivago/prettier-plugin-sort-imports": ^4.3.0
-    "@types/node": ^18.19.130
+    "@types/node": ^24
     "@types/react": ^19.2.14
     "@uniswap/sdk-core": ^5.8.2
     "@uniswap/v2-sdk": ^4.6.1
@@ -6734,21 +6734,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^18.19.130":
-  version: 18.19.130
-  resolution: "@types/node@npm:18.19.130"
-  dependencies:
-    undici-types: ~5.26.4
-  checksum: b7032363581c416e721a88cffdc2b47662337cacd20f8294f5619a1abf79615c7fef1521964c2aa9d36ed6aae733e1a03e8c704661bd5a0c2f34b390f41ea395
-  languageName: node
-  linkType: hard
-
 "@types/node@npm:^20.0.0, @types/node@npm:^20.10.7":
   version: 20.19.13
   resolution: "@types/node@npm:20.19.13"
   dependencies:
     undici-types: ~6.21.0
   checksum: 173975790cd21f0fcbaaf7fde597ff14f84faed7a3d93ae9cb66698e637309ed7223e3bc6380e3f1f4ea1a49bb90b76e8ab424efed2939b1da1639cb595de618
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^24":
+  version: 24.13.3
+  resolution: "@types/node@npm:24.13.3"
+  dependencies:
+    undici-types: ~7.18.0
+  checksum: e3f2142e02dd7b44885bf16d5438e7d510c5917a272011ac594665fe38f453dea810cb4c8cd989d6cbaf769d46dbaf017eee4bdbf4246737f2b6c6774e093332
   languageName: node
   linkType: hard
 
@@ -19182,6 +19182,13 @@ __metadata:
   version: 7.10.0
   resolution: "undici-types@npm:7.10.0"
   checksum: 6917fcd8c80963919fe918952f9243a6749af0e3f759a39f8d2c2486144a66c86ae4125aebbce700b636cb1dcd45e85eb8c49c60d60738a97b63f0e89ef9b053
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~7.18.0":
+  version: 7.18.2
+  resolution: "undici-types@npm:7.18.2"
+  checksum: 23da306c8366574adec305b06a8519ab5c7d09e3f5d16c1a98709a34fae17da09ec95198f30f86c00055e02efa8bfcc843e84e8aebeb9b8d6bb3e06afccae07a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps `@types/node` to `^24` to match the Node 24 runtime used in CI.

`yarn next:check-types` output (empty means success):
```
$ yarn next:check-types
(no output)
```

No type errors needed to be fixed, as the current code in `packages/nextjs` does not use any incompatible `fs`, `stream`, or `global` APIs that break with the newer type definitions.