### PR TITLE
Fix duplicated logs in block explorer

### DIFF
--- a/packages/nextjs/hooks/scaffold-eth/useContractLogs.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useContractLogs.ts
@@ -9,31 +9,67 @@ export const useContractLogs = (address: Address) => {
   const client = usePublicClient({ chainId: targetNetwork.id });
 
   useEffect(() => {
+    setLogs([]);
+    let unwatch: (() => void) | undefined;
+    let lastFetchedBlock = 0n;
+    // Set to true on effect cleanup. Guards against in-flight fetchLogs completing after
+    // unmount or re-run (e.g. React Strict Mode, address/client change) and registering
+    // a duplicate watcher or calling setLogs with stale data.
+    let ignore = false;
+
     const fetchLogs = async () => {
       if (!client) return console.error("Client not found");
       try {
+        const latestBlock = await client.getBlockNumber();
+        if (ignore) return;
+
         const existingLogs = await client.getLogs({
           address: address,
           fromBlock: 0n,
-          toBlock: "latest",
+          toBlock: latestBlock,
         });
+        if (ignore) return;
+
+        lastFetchedBlock = latestBlock;
         setLogs(existingLogs);
+
+        unwatch = client.watchBlockNumber({
+          onBlockNumber: async blockNumber => {
+            const fromBlock = lastFetchedBlock + 1n;
+            if (fromBlock > blockNumber) return;
+
+            // Advance cursor before await so concurrent block callbacks don't overlap
+            lastFetchedBlock = blockNumber;
+
+            try {
+              const newLogs = await client.getLogs({
+                address: address,
+                fromBlock: fromBlock,
+                toBlock: blockNumber,
+              });
+              if (ignore) return;
+
+              if (newLogs.length > 0) {
+                setLogs(prevLogs => [...prevLogs, ...newLogs]);
+              }
+            } catch (error) {
+              // Roll back the cursor so the next block callback retries this range
+              lastFetchedBlock = fromBlock - 1n;
+              console.error("Failed to fetch logs:", error);
+            }
+          },
+        });
       } catch (error) {
         console.error("Failed to fetch logs:", error);
       }
     };
+
     fetchLogs();
 
-    return client?.watchBlockNumber({
-      onBlockNumber: async (_blockNumber, prevBlockNumber) => {
-        const newLogs = await client.getLogs({
-          address: address,
-          fromBlock: prevBlockNumber,
-          toBlock: "latest",
-        });
-        setLogs(prevLogs => [...prevLogs, ...newLogs]);
-      },
-    });
+    return () => {
+      ignore = true;
+      unwatch?.();
+    };
   }, [address, client]);
 
   return logs;


### PR DESCRIPTION
Port upstream scaffold-eth-2 fix for duplicated logs in the block explorer.
Upstream PR: scaffold-eth/scaffold-eth-2#1300

Test output (`yarn next:check-types && yarn next:lint`):
```
/Users/q3labsadmin/Q3/ScaffoldStylus/scaffold-stylus/.worktrees/scaffold-stylus-logs-fix/packages/nextjs/components/scaffold-eth/FaucetButton.tsx
  14:7  warning  'FAUCET_ADDRESS' is assigned a value but never used  @typescript-eslint/no-unused-vars

/Users/q3labsadmin/Q3/ScaffoldStylus/scaffold-stylus/.worktrees/scaffold-stylus-logs-fix/packages/nextjs/components/scaffold-eth/Input/IntegerInput.tsx
  21:9  warning  'isDarkMode' is assigned a value but never used  @typescript-eslint/no-unused-vars

✖ 2 problems (0 errors, 2 warnings)
```
