### PR TITLE
chore: devx fixes for readme and polling interval

### DIFF
--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -28,7 +28,7 @@ const scaffoldConfig = {
 
   // The interval at which your front-end polls the RPC servers for new data
   // it has no effect if you only target the local network (default is 4000)
-  pollingInterval: 30000,
+  pollingInterval: 3000,
 
   // This is ours Alchemy's default API key.
   // You can get your own at https://dashboard.alchemyapi.io

--- a/readme.md
+++ b/readme.md
@@ -41,22 +41,9 @@ Before you begin, you need to install the following tools:
 
 To get started with Scaffold-Stylus, follow the steps below:
 
-### 1. Install Stylus tools (or use stylusup)
+### 1. Install Stylus tools
 
-If you prefer a one-liner, install via stylusup (recommended):
-
-Tool for installing all the Stylus essentials for development. [Stylusup](https://stylusup.sh/#) will install the latest stable versions of:
-
-- [Rust](https://www.rust-lang.org/tools/install) (if not present) to provide the core programming environment.
-- [cargo-stylus](https://github.com/OffchainLabs/cargo-stylus/blob/main/README.md) (latest version) a tool for creating and managing Stylus projects.
-- Adding WebAssembly support to compile Rust code for blockchain environments.
-- Optionally collecting and sending telemetry data to track installation statistics.
-
-```bash
-curl -s https://stylusup.sh/install.sh | sh
-```
-
-### Alternatively, install Rust and the Stylus CLI tool with Cargo:
+First, install Rust and Cargo:
 
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
@@ -64,7 +51,9 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 Check the [Rust installation guide](https://www.rust-lang.org/tools/install) for more information.
 
-Then install the Stylus CLI tools:
+Then install the Stylus CLI tools.
+
+> **⚠️ WARNING:** This project requires `cargo-stylus` version `0.10.2` and `rustc` version `1.89` (as pinned in `packages/stylus/contracts/rust-toolchain.toml`). Do NOT use `stylusup` to install Stylus tools, as it installs the latest versions which are incompatible with these pinned requirements.
 
 ```bash
 cargo install --force --locked cargo-stylus@0.10.2


### PR DESCRIPTION
Fixes two developer experience issues:
1. Fixed `readme.md` contradicting itself. Removed the `stylusup` recommendation which forces the latest versions of Rust and `cargo-stylus`, thereby breaking compatibility with the pinned versions (`rustup default 1.89` and `cargo-stylus@0.10.2`). Replaced it with a clear, explicit warning to use the correct pinned versions.
2. Updated frontend polling interval from `30000` to `3000` (in `packages/nextjs/scaffold.config.ts`) for faster devx (following upstream scaffold-eth-2).
   - **RPC Finding**: Verified that the `targetNetworks` setting defaults to `[chains.arbitrumNitro]`, which points to a local RPC endpoint (`http://localhost:8547`). Hence, the 10x more frequent polling will only hit the local dev node and won't consume a public/shared endpoint's rate limits.