### PR TITLE
feat(skills): add smoke-test skill (phase 1.5 gate)

### DIFF
--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -1,0 +1,358 @@
+---
+name: smoke-test
+description: Use when validating scaffold-stylus after update-check (phase 1) upgrades are merged and before sibling-sync (phase 2) propagates them, to confirm the devnode -> deploy -> ABI export -> scaffold hooks -> tx signing -> read-back chain still works end to end. Triggers on requests to smoke-test, phase 1.5, or gate sibling-sync.
+---
+
+# Smoke Test (Phase 1.5)
+
+## Overview
+
+This is the Phase 1.5 gate between `update-check` (Phase 1, dependency
+audit/upgrade) and `sibling-sync` (Phase 2, propagation to `create-stylus`,
+`create-stylus-extensions`, and `docs`). Phase 1 upgrades touch Rust/Node
+toolchains and dependency versions that `cargo stylus check`, `yarn`, and CI
+alone cannot fully validate — they don't prove a contract still *activates*
+on the local devnode, that its ABI still reaches the frontend, or that a
+burner-wallet transaction still round-trips. This skill runs that full
+chain for real and reports a verdict that gates whether Phase 2 is allowed
+to proceed.
+
+**READ-ONLY CONTRACT:** This skill is STRICTLY READ-ONLY with respect to
+committed repository source. It runs the stack, deploys throwaway
+contracts, and drives a browser — it MUST NOT edit `.rs`, `.ts`, `.tsx`,
+`.toml`, or any other tracked source file to make a failing step pass.
+If a step fails, report it as failed; do not "fix" it by editing code.
+The only tracked files this skill's own steps are permitted to touch are
+build artifacts it must restore in Step 8 (`deployedContracts.ts`) — see
+that step for the exact restore command.
+
+## Ordering Contract
+
+1. `update-check` (Phase 1) — audits and upgrades dependencies.
+2. Phase 1 upgrade PR(s) are merged to `main`.
+3. **`smoke-test` (Phase 1.5) — you are here.** Validates the merged
+   upgrades against the real stack.
+4. `sibling-sync` (Phase 2) — propagates the validated state to sibling
+   repos. **Only runs if this skill's verdict is PASS.**
+
+## Non-Negotiable Reporting Rule (tri-state)
+
+Copy this rule verbatim in behavior from `update-check` and `sibling-sync`:
+every step below reports **exactly one** of three states — never two,
+never a blend:
+
+- **(a) RAN and passed** — the command executed and its concrete assertion
+  held.
+- **(b) DID NOT RUN** — a tool was missing, a port was busy, an env var
+  was absent, or the step timed out waiting on something external. **(b)
+  is not a pass.** It means the step gives no evidence either way.
+- **(c) RAN and failed** — the command executed and its assertion did not
+  hold, or the command exited non-zero for a reason other than a missing
+  prerequisite.
+
+**Verdict:**
+- **PASS** — every required step (1 through 7) is (a).
+- **INCONCLUSIVE** — any step is (b). Fix the missing prerequisite and
+  re-run; do not treat INCONCLUSIVE as "probably fine."
+- **FAIL** — any step is (c).
+
+Neither INCONCLUSIVE nor FAIL opens the Phase 2 (`sibling-sync`) gate.
+Step 8 (teardown) always runs regardless of verdict and is not itself
+part of the PASS/INCONCLUSIVE/FAIL calculation — but a teardown failure
+must still be reported, since a leaked devnode poisons the next run.
+
+## Step 0 — Preflight
+
+```bash
+./.claude/skills/smoke-test/preflight.sh
+```
+
+Checks (in order): `node`, `yarn`, `docker` binary + daemon reachability
+(`docker info`), `cast` (Foundry), `cargo`, `cargo stylus`, the
+`SMOKE_TEST_CONFIRM` env gate (see Step 1), ports 8547/3000 free, and that
+no artifact from a prior unclean run is already sitting in the working
+tree (`packages/nextjs/contracts/deployedContracts.ts`,
+`packages/stylus/deployments`, `packages/stylus/contracts/erc20-example`).
+
+- Exit 0 → proceed to Step 2.
+- Exit 1 (missing tool) or 3 (port busy) or 4 (dirty tree from a leaked
+  prior run) → **(b) DID NOT RUN** for every downstream step; stop here.
+- Exit 2 (env gate closed) → see Step 1; **(b) DID NOT RUN** for the whole
+  run.
+
+## Step 1 — Env Gate
+
+Explicit opt-in is required before this skill touches anything:
+
+```bash
+export SMOKE_TEST_CONFIRM=1
+```
+
+**Why a gate:** this skill binds host ports 8547 and 3000, runs a Docker
+container, deploys real (if throwaway) contracts, and drives a live
+browser session with a burner wallet. It must never fire as a silent side
+effect of another skill or an automated loop.
+
+- `SMOKE_TEST_CONFIRM` set → **(a)**, proceed.
+- Unset → **(b) DID NOT RUN — env absent.** Tell the caller to set it and
+  stop; do not assume consent.
+
+## Step 2 — Start the devnode
+
+```bash
+yarn chain &
+CHAIN_PID=$!
+```
+
+This runs `nitro-devnode/start-chain-with-cors.sh`, which `docker run
+--name nitro-dev -p 8547:8547 ...`, waits for the RPC, calls
+`becomeChainOwner()`, and (as of the ArbOS-60 fix) schedules the ArbOS 60
+upgrade itself. Do not schedule it again here — Step 3 only *verifies* it
+landed.
+
+Assertion — poll until the RPC answers, capped at 90s:
+
+```bash
+timeout 90 bash -c \
+  'until curl -s -X POST -H "Content-Type: application/json" \
+     --data "{\"jsonrpc\":\"2.0\",\"method\":\"net_version\",\"params\":[],\"id\":1}" \
+     http://127.0.0.1:8547 | grep -q result; do sleep 1; done'
+```
+
+- `docker` fails to pull/start the image (daemon issue, network issue) →
+  **(b) DID NOT RUN — devnode failed to boot** (external/environmental,
+  not a code regression).
+- Image starts but the RPC never answers within 90s, or the container
+  exits, or `becomeChainOwner()`/CREATE2-factory/Cache-Manager/
+  StylusDeployer setup inside the script errors out → **(c) RAN and
+  failed** (this is the stack itself misbehaving — a real regression
+  candidate).
+- RPC answers within the timeout → **(a)**.
+
+## Step 3 — ArbOS Assertion (regression gate for the multi-fragment fix)
+
+This directly re-checks the fix landed in `db5dfcf` / PR #80: the dev node
+boots at ArbOS 59 and must be moved to ArbOS 60, or every >24KB
+(multi-fragment) Stylus contract will revert on activation.
+
+```bash
+cast call --rpc-url http://127.0.0.1:8547 \
+  0x0000000000000000000000000000000000000064 \
+  "arbOSVersion()(uint64)"
+```
+
+Assertion: output must be **115** (55 + ArbOS 60). `114` means the chain
+is stuck at ArbOS 59.
+
+- `cast` errors (RPC unreachable) → **(b) DID NOT RUN** (Step 2 already
+  should have caught this; treat as devnode instability).
+- Output is `114` → **(c) RAN and failed — devnode stuck at ArbOS 59;
+  multi-fragment deploys will revert.** This is a real regression: it
+  means `nitro-devnode/start-chain-with-cors.sh`'s
+  `scheduleArbOSUpgrade(60, 0)` call regressed or the pinned image
+  (`NITRO_NODE_VERSION` in that script) was downgraded below v3.10.0.
+- Output is `115` → **(a)**.
+
+## Step 4 — Deploy the default contract (deploy -> ABI export -> scaffold hooks)
+
+```bash
+yarn deploy
+```
+
+This runs `cargo stylus deploy` against `packages/stylus/contracts/
+your-contract`, then automatically runs `cargo stylus export-abi` and
+writes the address/ABI into `packages/nextjs/contracts/
+deployedContracts.ts` (chain id `412346`) — the file the Next.js scaffold
+hooks (`useScaffoldReadContract`/`useScaffoldWriteContract`) read from.
+
+Assertion — all three must hold:
+
+```bash
+test -f packages/stylus/deployments/412346_latest.json
+grep -q '"your-contract"' packages/nextjs/contracts/deployedContracts.ts
+grep -q '412346' packages/nextjs/contracts/deployedContracts.ts
+```
+
+- `yarn` itself missing, or `.env`/network resolution errors before any
+  RPC call is attempted → **(b) DID NOT RUN**.
+- `cargo stylus deploy` exits non-zero, or exits 0 but
+  `deployedContracts.ts` doesn't contain the new entry (export-abi step
+  silently failed) → **(c) RAN and failed**.
+- All three checks pass → **(a)**.
+
+## Step 5 — Deploy a >24KB (multi-fragment) contract
+
+This is the end-to-end proof for Step 3's regression gate: an ArbOS
+report of 115 is meaningless if a real multi-fragment contract still
+reverts. Reuse the exact contract type PR #80 verified (25.1KB / 2
+fragments) by scaffolding it fresh from `create-stylus` rather than hand-
+authoring new Rust for this skill:
+
+```bash
+npx create-stylus@latest smoke-fixture -e erc-20 --skip-install --skip-git
+cp -r smoke-fixture/packages/stylus/contracts/erc20-example \
+  packages/stylus/contracts/erc20-example
+rm -rf smoke-fixture
+```
+
+`packages/stylus/contracts/` is a Cargo workspace with `members = ["*"]`
+(see `packages/stylus/contracts/Cargo.toml`), so the copied crate joins
+the workspace automatically — no `Cargo.toml` edit needed. This directory
+is skill-owned scratch, not repo source; it is deleted in Step 8 and must
+never be `git add`ed.
+
+```bash
+cd packages/stylus/contracts/erc20-example
+cargo stylus check --endpoint http://127.0.0.1:8547
+cargo stylus deploy --endpoint http://127.0.0.1:8547 \
+  --private-key 0xb6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659 \
+  --no-verify
+cd -
+```
+
+(The private key is the nitro-devnode's well-known prefunded dev account,
+the same one `nitro-devnode/start-chain-with-cors.sh` uses — not a secret.)
+
+Assertion: `cargo stylus check` reports a WASM size over 24576 bytes /
+2+ activation fragments, and `cargo stylus deploy` completes with a
+receipt status of 1 (no `execution reverted`).
+
+- `npx create-stylus@latest` fails to fetch (network/npm registry issue)
+  → **(b) DID NOT RUN**.
+- The fetched fixture is under 24KB / 1 fragment (upstream template
+  shrank) → **(b) DID NOT RUN — fixture no longer exceeds the
+  multi-fragment threshold; this step proves nothing until the fixture is
+  swapped for a bigger one.**
+- `cargo stylus check` or `deploy` errors with `execution reverted` while
+  the fixture is confirmed >24KB → **(c) RAN and failed** — this is
+  exactly the regression PR #80 fixed, resurfacing.
+- Check and deploy both succeed on a confirmed >24KB fixture → **(a)**.
+
+## Step 6 — Start the frontend
+
+```bash
+yarn start &
+NEXTJS_PID=$!
+```
+
+Runs `next dev` (port 3000) via the `@ss/nextjs` workspace.
+
+Assertion — poll up to 90s (first compile can be slow):
+
+```bash
+timeout 90 bash -c \
+  'until [ "$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000)" = "200" ]; do sleep 2; done'
+```
+
+- Port 3000 already bound, or the process exits immediately → **(b) DID
+  NOT RUN** if caused by environment (should have been caught in
+  preflight); **(c)** if `next dev` starts then crashes with a build/type
+  error.
+- Responds 200 within 90s → **(a)**.
+
+## Step 7 — Browser E2E (the whole chain, proven live)
+
+Use the `claude-in-chrome` browser tools for this step. Load them first
+(`ToolSearch` for `tabs_context_mcp`, `navigate`, `computer`, `read_page`,
+`tabs_create_mcp`) if not already loaded.
+
+**Never trigger a native browser dialog** (`alert`/`confirm`/`prompt`).
+This scaffold's flows (burner wallet, debug page) do not require one, but
+if any UI element looks like it might spawn one (e.g. a "reset" or
+"clear" button), skip it — a triggered dialog freezes the automation and
+the session must then be unblocked by hand.
+
+1. Navigate to `http://localhost:3000/debug`.
+2. **Assert `your-contract` appears in the debug contract list with its
+   read/write methods rendered** — not just that the page returned 200.
+   A page that merely renders is not a pass; you must see the specific
+   deployed contract with a live address.
+3. Connect the wallet: click Connect → select the local burner wallet
+   (RainbowKit `rainbowkitBurnerWallet`, wired in
+   `packages/nextjs/services/web3/wagmiConnectors.tsx` — it signs locally,
+   no external wallet popup, so it cannot itself trigger a native dialog).
+4. Call the read method `greeting()`. Assert it returns
+   `"Building Unstoppable Apps!!!"` (the constructor default in
+   `packages/stylus/contracts/your-contract/src/lib.rs`).
+5. Call the write method `setGreeting("smoke-test-<distinct-value>")`
+   with a value distinguishable from the default, and let the burner
+   wallet sign it. Wait for the transaction to confirm (success toast /
+   receipt in the UI).
+6. Call `greeting()` again. **Assert it now returns the value you just
+   set.** This read-back is what proves the full chain — devnode ->
+   deploy -> ABI generation -> scaffold hooks -> tx signing -> read-back
+   — not just that a page rendered.
+7. Take a screenshot as evidence of the read-back value on the debug
+   page, and keep it with the run's report.
+
+- Chrome extension / browser tools unavailable, or the debug page never
+  loads → **(b) DID NOT RUN — browser automation unavailable**.
+- Wallet won't connect, write tx reverts or never confirms, or the
+  read-back value doesn't match what was written → **(c) RAN and
+  failed**, with the mismatch and any console/network errors attached.
+- All of steps 2–6 hold and the screenshot is captured → **(a)**.
+
+## Step 8 — Teardown (ALWAYS, including on failure)
+
+Run this regardless of the verdict from Steps 1–7 — on PASS, FAIL, or a
+crash partway through. A leaked devnode or dev server poisons the *next*
+run, and it will look like a port conflict in Step 0, not like "the last
+run left something running."
+
+```bash
+# 1. Kill the Next.js dev server
+kill "$NEXTJS_PID" 2>/dev/null
+pkill -f "next dev" 2>/dev/null
+
+# 2. Tear down the devnode container
+docker rm -f nitro-dev
+
+# 3. Kill the backgrounded chain script if still around
+kill "$CHAIN_PID" 2>/dev/null
+
+# 4. Remove the Step 5 scratch fixture — never let it reach git status
+rm -rf packages/stylus/contracts/erc20-example
+
+# 5. Restore the tracked file Step 4 legitimately modified
+git checkout -- packages/nextjs/contracts/deployedContracts.ts
+
+# 6. Remove the gitignored deployment artifacts Step 4 wrote
+rm -rf packages/stylus/deployments
+
+# 7. Verify no orphaned processes or dirty tree remain
+docker ps -a --filter name=nitro-dev --format '{{.Names}}'   # expect empty
+pgrep -f "next dev"                                          # expect no match
+pgrep -f "start-chain-with-cors.sh"                           # expect no match
+git status --porcelain -- packages/nextjs/contracts/deployedContracts.ts \
+  packages/stylus/deployments packages/stylus/contracts/erc20-example
+                                                               # expect empty
+```
+
+- If any verification in step 7 above is non-empty, teardown itself
+  **failed** — report this explicitly (it is not covered by the PASS/
+  INCONCLUSIVE/FAIL verdict, but it must be surfaced, since it will
+  cause the *next* run's Step 0 preflight to fail with a misleading
+  "port busy" or "dirty tree" message).
+- `deployedContracts.ts` is the one tracked file this skill is allowed to
+  touch mid-run (Step 4) — teardown's `git checkout --` on it is what
+  keeps the READ-ONLY contract's spirit intact: the working tree must be
+  bit-for-bit unchanged by the time this skill exits.
+
+## Common Mistakes
+
+- Treating a missing tool, closed env gate, or busy port as anything
+  other than **(b)**. These are silent-pass traps — they must surface as
+  INCONCLUSIVE, never PASS.
+- Skipping Step 3 because Step 2's script "already handles ArbOS 60" —
+  Step 2 *attempts* the upgrade; Step 3 is the independent verification
+  that it actually landed on this run's container.
+- Skipping Step 5 because Step 4's small contract deployed fine —
+  `your-contract` is under the 24KB single-fragment threshold and cannot
+  exercise the multi-fragment code path at all.
+- Calling Step 7 a pass because `/debug` returned 200. Rendering proves
+  nothing about the deploy/ABI/signing chain; only the read-back
+  assertion in Step 7.6 does.
+- Editing `nitro-devnode/*.sh`, contract source, or frontend hooks to
+  make a failing step pass. This skill is READ-ONLY — report the failure
+  instead.
+- Running Step 8 only on success. Teardown is unconditional.

--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -69,18 +69,24 @@ must still be reported, since a leaked devnode poisons the next run.
 
 Checks (in order): `node`, `yarn`, `docker` binary + daemon reachability
 (`docker info`), `cast` (Foundry), `cargo`, `cargo stylus`, the
-`SMOKE_TEST_CONFIRM` env gate (see Step 1), ports 8547/3000 free, and that
-no artifact from a prior unclean run is already sitting in the working
-tree (`packages/nextjs/contracts/deployedContracts.ts`,
+`SMOKE_TEST_CONFIRM` consent gate and the `packages/stylus/.env`
+deploy-credentials gate (see Step 1), ports 8547/3000 free, and that no
+artifact from a prior unclean run is already sitting in the working tree
+(`packages/nextjs/contracts/deployedContracts.ts`,
 `packages/stylus/deployments`, `packages/stylus/contracts/erc20-example`).
 
 - Exit 0 → proceed to Step 2.
-- Exit 1 (missing tool) or 3 (port busy) or 4 (dirty tree from a leaked
+- Exit 1 (missing tool), 3 (port busy), or 4 (dirty tree from a leaked
   prior run) → **(b) DID NOT RUN** for every downstream step; stop here.
-- Exit 2 (env gate closed) → see Step 1; **(b) DID NOT RUN** for the whole
-  run.
+- Exit 2 (consent gate closed) or 5 (deploy-credentials gate closed) →
+  see Step 1; **(b) DID NOT RUN** for the whole run.
 
-## Step 1 — Env Gate
+## Step 1 — Gates (two, both required)
+
+Two distinct, independent gates must both pass before Step 2 starts the
+devnode. Neither is optional and neither substitutes for the other.
+
+### Step 1a — Consent gate
 
 Explicit opt-in is required before this skill touches anything:
 
@@ -96,6 +102,44 @@ effect of another skill or an automated loop.
 - `SMOKE_TEST_CONFIRM` set → **(a)**, proceed.
 - Unset → **(b) DID NOT RUN — env absent.** Tell the caller to set it and
   stop; do not assume consent.
+
+### Step 1b — Deploy-credentials gate
+
+`yarn deploy` (Step 4) reads its devnet `ACCOUNT_ADDRESS` / `RPC_URL` /
+`PRIVATE_KEY` from `packages/stylus/.env`. That file does not exist in a
+fresh clone, and `packages/stylus/.env.example` ships its entire `##
+devnet` block commented out (only `DEPLOYMENT_DIR=` is uncommented, and
+it's blank). Without this gate, Step 4 dies on a missing/blank value
+*after* Step 2 has already bound ports and started Docker — check this
+**before** Step 2, not after.
+
+`preflight.sh` checks that `packages/stylus/.env` exists and has
+non-blank, uncommented `ACCOUNT_ADDRESS=`, `RPC_URL=`, and `PRIVATE_KEY=`
+lines. It never reads the rest of the file's contents back to the
+terminal (that file may also hold real sepolia/mainnet secrets in other
+blocks) and it never creates or edits the file itself.
+
+- All three devnet keys present and non-blank → **(a)**, proceed.
+- File missing, or any of the three keys missing/blank → **(b) DID NOT
+  RUN — env absent.** Halt and ask a human to create/edit
+  `packages/stylus/.env` with this exact block — these are the
+  nitro-devnode's own well-known prefunded dev values (the private key is
+  hardcoded in plaintext at `nitro-devnode/run-dev-node.sh` line 7), not a
+  secret to invent or protect:
+
+  ```
+  DEPLOYMENT_DIR=deployments
+
+  ## devnet
+  ACCOUNT_ADDRESS=0x3f1Eae7D46d88F08fc2F8ed27FCb2AB183EB2d0E
+  RPC_URL=http://127.0.0.1:8547
+  PRIVATE_KEY=0xb6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659
+  ```
+
+  Never auto-write this block into `.env` on the human's behalf, never
+  invent or guess different values, and never echo back any *other*
+  content already in the file (it may contain real secrets for other
+  networks).
 
 ## Step 2 — Start the devnode
 
@@ -212,6 +256,17 @@ cd -
 
 (The private key is the nitro-devnode's well-known prefunded dev account,
 the same one `nitro-devnode/start-chain-with-cors.sh` uses — not a secret.)
+
+**Use `cargo stylus check` to measure/validate the contract. Do NOT use
+plain `cargo build`.** `cargo build` fails on the host target for this
+contract (and for `your-contract`) because of a known
+`openzeppelin-stylus 0.3.0` / `stylus-sdk 0.9.0` VM mismatch — it is
+**expected and pre-existing**, not a regression, and not caused by any
+toolchain upgrade. A rustc 1.89 -> 1.91 bump is in flight on another
+branch right now; if you run `cargo build` here and hit this failure, do
+not attribute it to that upgrade and do not report it as a bug to fix —
+`cargo stylus check` (which builds for `wasm32-unknown-unknown`, not the
+host) is the correct command and does not hit this mismatch.
 
 Assertion: `cargo stylus check` reports a WASM size over 24576 bytes /
 2+ activation fragments, and `cargo stylus deploy` completes with a

--- a/.claude/skills/smoke-test/preflight.sh
+++ b/.claude/skills/smoke-test/preflight.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# .claude/skills/smoke-test/preflight.sh
+#
+# Preflight for the Phase 1.5 smoke-test skill. Every check here maps to a
+# (b) DID NOT RUN reason in the skill's tri-state report — a failure here
+# means a prerequisite is missing, NOT that the smoke test itself failed.
+# This script never starts docker, deploys a contract, or touches repo
+# source; it only verifies the environment is ready to attempt Step 0-8.
+#
+# Exit codes:
+#   0  - all checks passed, safe to proceed to Step 1 (env gate)
+#   1  - a required tool is missing
+#   2  - the env gate (SMOKE_TEST_CONFIRM) is not set
+#   3  - a required port (8547 or 3000) is already bound
+#   4  - the working tree already has a dirty deployedContracts.ts / deployments
+#        artifact, meaning a prior run leaked and was never torn down
+
+set -u
+FAILED=0
+
+check_cmd() {
+  local name="$1"
+  local hint="$2"
+  if ! command -v "$name" &>/dev/null; then
+    echo "MISSING: $name — $hint"
+    FAILED=1
+  else
+    echo "OK: $name ($(command -v "$name"))"
+  fi
+}
+
+echo "=== Tool checks ==="
+check_cmd node "install Node.js (repo uses Yarn Berry workspaces)"
+check_cmd yarn "corepack enable or npm i -g yarn"
+check_cmd docker "Docker Desktop must be installed and running"
+check_cmd cast "install Foundry (curl -L https://foundry.paradigm.xyz | bash && foundryup)"
+check_cmd cargo "install Rust via rustup"
+
+if ! cargo stylus --version &>/dev/null; then
+  echo "MISSING: cargo-stylus — cargo install cargo-stylus"
+  FAILED=1
+else
+  echo "OK: cargo-stylus ($(cargo stylus --version 2>&1 | head -1))"
+fi
+
+if [ "$FAILED" -ne 0 ]; then
+  echo ""
+  echo "Preflight FAILED: one or more required tools are missing."
+  echo "Report each missing tool's step as (b) DID NOT RUN — tool missing."
+  exit 1
+fi
+
+echo ""
+echo "=== Docker daemon check ==="
+if ! docker info &>/dev/null; then
+  echo "MISSING: docker daemon is not reachable (Docker Desktop not running?)"
+  echo "Report Step 2 (start devnode) as (b) DID NOT RUN — docker daemon unreachable."
+  exit 1
+fi
+echo "OK: docker daemon reachable"
+
+echo ""
+echo "=== Env gate check ==="
+if [ -z "${SMOKE_TEST_CONFIRM:-}" ]; then
+  echo "GATE CLOSED: SMOKE_TEST_CONFIRM is not set."
+  echo "This skill starts a Docker container bound to host ports 8547/3000,"
+  echo "deploys throwaway contracts, and drives a live browser session."
+  echo "Set SMOKE_TEST_CONFIRM=1 to explicitly opt in, then re-run."
+  echo "Report Step 1 (env gate) as (b) DID NOT RUN — env absent."
+  exit 2
+fi
+echo "OK: SMOKE_TEST_CONFIRM=${SMOKE_TEST_CONFIRM}"
+
+echo ""
+echo "=== Port checks ==="
+for port in 8547 3000; do
+  if lsof -i ":${port}" -sTCP:LISTEN &>/dev/null; then
+    echo "BUSY: port ${port} is already bound — a leaked devnode/dev-server"
+    echo "from a prior smoke-test run is the most likely cause (check for an"
+    echo "orphaned 'nitro-dev' container or 'next dev' process before retrying)."
+    FAILED=3
+  else
+    echo "OK: port ${port} free"
+  fi
+done
+
+if [ "$FAILED" -ne 0 ]; then
+  echo ""
+  echo "Preflight FAILED: report the blocked step as (b) DID NOT RUN — port busy."
+  exit 3
+fi
+
+echo ""
+echo "=== Working tree cleanliness check ==="
+DIRTY=$(git status --porcelain -- packages/nextjs/contracts/deployedContracts.ts packages/stylus/deployments packages/stylus/contracts/erc20-example 2>/dev/null)
+if [ -n "$DIRTY" ]; then
+  echo "DIRTY: a previous smoke-test run left artifacts uncleaned:"
+  echo "$DIRTY"
+  echo "This means a prior run's Step 8 teardown did not complete. Clean it"
+  echo "manually (git checkout -- packages/nextjs/contracts/deployedContracts.ts;"
+  echo "rm -rf packages/stylus/deployments packages/stylus/contracts/erc20-example)"
+  echo "before treating this run's results as trustworthy."
+  exit 4
+fi
+echo "OK: no leaked artifacts from a prior run"
+
+echo ""
+echo "Preflight PASSED. Safe to proceed to Step 2 (start devnode)."
+exit 0

--- a/.claude/skills/smoke-test/preflight.sh
+++ b/.claude/skills/smoke-test/preflight.sh
@@ -8,9 +8,11 @@
 # source; it only verifies the environment is ready to attempt Step 0-8.
 #
 # Exit codes:
-#   0  - all checks passed, safe to proceed to Step 1 (env gate)
+#   0  - all checks passed, safe to proceed to Step 2 (start devnode)
 #   1  - a required tool is missing
-#   2  - the env gate (SMOKE_TEST_CONFIRM) is not set
+#   2  - the consent gate (SMOKE_TEST_CONFIRM) is not set
+#   5  - the deploy-credentials gate: packages/stylus/.env is missing or has
+#        a blank/absent ACCOUNT_ADDRESS, RPC_URL, or PRIVATE_KEY for devnet
 #   3  - a required port (8547 or 3000) is already bound
 #   4  - the working tree already has a dirty deployedContracts.ts / deployments
 #        artifact, meaning a prior run leaked and was never torn down
@@ -60,16 +62,62 @@ fi
 echo "OK: docker daemon reachable"
 
 echo ""
-echo "=== Env gate check ==="
+echo "=== Step 1a: consent gate check ==="
 if [ -z "${SMOKE_TEST_CONFIRM:-}" ]; then
   echo "GATE CLOSED: SMOKE_TEST_CONFIRM is not set."
   echo "This skill starts a Docker container bound to host ports 8547/3000,"
   echo "deploys throwaway contracts, and drives a live browser session."
   echo "Set SMOKE_TEST_CONFIRM=1 to explicitly opt in, then re-run."
-  echo "Report Step 1 (env gate) as (b) DID NOT RUN — env absent."
+  echo "Report Step 1a (consent gate) as (b) DID NOT RUN — env absent."
   exit 2
 fi
 echo "OK: SMOKE_TEST_CONFIRM=${SMOKE_TEST_CONFIRM}"
+
+echo ""
+echo "=== Step 1b: deploy-credentials gate check (packages/stylus/.env) ==="
+# 'yarn deploy' (Step 4) reads devnet ACCOUNT_ADDRESS/RPC_URL/PRIVATE_KEY
+# from this file. packages/stylus/.env.example ships the whole devnet
+# block commented out, so a fresh clone has none of these set. Checked
+# here, before Step 2 starts the devnode, so we don't bind ports and boot
+# docker only to have 'yarn deploy' die on a missing file afterward.
+#
+# This check never prints the file's contents — only which of the three
+# expected key names are present and non-blank — because the same file
+# may also hold real sepolia/mainnet secrets in other (commented) blocks.
+ENV_FILE="packages/stylus/.env"
+env_key_present() {
+  [ -f "$ENV_FILE" ] && grep -Eq "^${1}=[^[:space:]]" "$ENV_FILE"
+}
+
+MISSING_KEYS=""
+for key in ACCOUNT_ADDRESS RPC_URL PRIVATE_KEY; do
+  if ! env_key_present "$key"; then
+    MISSING_KEYS="$MISSING_KEYS $key"
+  fi
+done
+
+if [ -n "$MISSING_KEYS" ]; then
+  echo "GATE CLOSED: ${ENV_FILE} is missing or blank for:${MISSING_KEYS}"
+  echo ""
+  echo "This skill will NOT create or edit ${ENV_FILE} for you, and will"
+  echo "NOT invent or guess values. Paste this block into ${ENV_FILE}"
+  echo "(create the file if it doesn't exist) — these are the"
+  echo "nitro-devnode's own well-known prefunded dev values, hardcoded in"
+  echo "plaintext at nitro-devnode/run-dev-node.sh line 7, not a secret:"
+  echo ""
+  cat <<'BLOCK'
+DEPLOYMENT_DIR=deployments
+
+## devnet
+ACCOUNT_ADDRESS=0x3f1Eae7D46d88F08fc2F8ed27FCb2AB183EB2d0E
+RPC_URL=http://127.0.0.1:8547
+PRIVATE_KEY=0xb6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659
+BLOCK
+  echo ""
+  echo "Report Step 1b (deploy-credentials gate) as (b) DID NOT RUN — env absent."
+  exit 5
+fi
+echo "OK: ${ENV_FILE} has non-blank ACCOUNT_ADDRESS/RPC_URL/PRIVATE_KEY"
 
 echo ""
 echo "=== Port checks ==="


### PR DESCRIPTION
## Summary
- Adds `.claude/skills/smoke-test/` as the Phase 1.5 validation gate between `update-check` (Phase 1) and `sibling-sync` (Phase 2).
- Every step has a concrete command, a concrete pass/fail assertion, and explicit tri-state reporting: **(a)** RAN and passed, **(b)** DID NOT RUN (tool missing/port busy/env absent/timeout — never a pass), **(c)** RAN and failed. Verdict is PASS only if every required step is (a); any (b) → INCONCLUSIVE, any (c) → FAIL; neither opens the Phase 2 gate.
- Step 0 preflight (`preflight.sh`) checks node/yarn/docker+daemon/cast/cargo/cargo-stylus, the `SMOKE_TEST_CONFIRM` env gate, ports 8547/3000, and leftover artifacts from an unclean prior run.
- Step 3 independently re-asserts `ArbSys.arbOSVersion() == 115` (ArbOS 60) — the regression gate for the multi-fragment fix landed in `db5dfcf`/#80.
- Step 5 deploys a real >24KB / multi-fragment contract (scaffolded fresh via `npx create-stylus@latest -e erc-20`, the same fixture type PR #80 verified) to prove the ArbOS assertion isn't just a number — a genuinely oversized contract must activate and deploy.
- Step 7 drives a live browser E2E (`/debug` page): connects the local burner wallet, calls a write method, and asserts the read-back value matches — proving devnode → deploy → ABI export → scaffold hooks → tx signing → read-back end to end, not just that a page renders. Explicitly warns against triggering native browser dialogs.
- Step 8 teardown is unconditional (kills the Next.js dev server, `docker rm -f nitro-dev`, removes the Step 5 scratch fixture, `git checkout --`s the one tracked file the run legitimately modifies (`deployedContracts.ts`), and verifies no orphaned processes/dirty tree remain).
- States the READ-ONLY contract and the update-check → merge → smoke-test → sibling-sync ordering explicitly.

This replaces the earlier rejected attempt (PR #87, closed) which was a 50-line generic template that dropped the ArbOS assertion, env gate, >24KB deploy, browser E2E, and teardown, and collapsed reporting into two states instead of three.

This PR only adds the skill's documentation/tooling — the smoke test itself was **not** run as part of authoring it.

## Test plan
- [x] `bash -n .claude/skills/smoke-test/preflight.sh` passes
- [x] `preflight.sh` is `chmod +x`
- [ ] A future run of the skill should exercise Steps 0–8 against a live devnode + browser (out of scope for this PR)