### PR TITLE
chore: upgrade cargo-stylus to 0.10.8 and rust toolchain to 1.91.0

### DIFF
--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Install cargo-stylus
         run: |
           cd source_repo
-          cargo install --force --locked cargo-stylus@0.10.2
+          cargo install --force --locked cargo-stylus@0.10.8
 
       - name: Install foundry cast
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -68,7 +68,7 @@ jobs:
             cargo-stylus --version
           else
             echo "Installing cargo-stylus..."
-            cargo install --force --locked cargo-stylus@0.10.2
+            cargo install --force --locked cargo-stylus@0.10.8
           fi
 
       - name: Cache Rust dependencies

--- a/packages/stylus/contracts/rust-toolchain.toml
+++ b/packages/stylus/contracts/rust-toolchain.toml
@@ -3,6 +3,6 @@
 [toolchain]
 # We should use stable here once nitro-testnode is updated and the contracts fit
 # the size limit (issue <https://github.com/OpenZeppelin/rust-contracts-stylus/issues/129>).
-channel = "1.89.0"
+channel = "1.91.0"
 components = ["rust-src", "rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]

--- a/readme.md
+++ b/readme.md
@@ -67,19 +67,19 @@ Check the [Rust installation guide](https://www.rust-lang.org/tools/install) for
 Then install the Stylus CLI tools:
 
 ```bash
-cargo install --force --locked cargo-stylus@0.10.2
+cargo install --force --locked cargo-stylus@0.10.8
 ```
 
 **Prerequisite:**
 
-- `cargo-stylus` version `0.10.2`
+- `cargo-stylus` version `0.10.8`
 - `rustc` version match with `packages/stylus/contracts/rust-toolchain.toml`
 
 Set default `toolchain` match `rust-toolchain.toml` and add the `wasm32-unknown-unknown` build target to your Rust compiler:
 
 ```bash
-rustup default 1.89
-rustup target add wasm32-unknown-unknown --toolchain 1.89
+rustup default 1.91.0
+rustup target add wasm32-unknown-unknown --toolchain 1.91.0
 ```
 
 You should now have it available as a Cargo subcommand:


### PR DESCRIPTION
## Summary
- Bump `cargo-stylus` 0.10.2 -> 0.10.8 in `.github/workflows/demo.yaml` and `.github/workflows/lint.yaml`
- Bump `packages/stylus/contracts/rust-toolchain.toml` channel 1.89.0 -> 1.91.0 (required: every cargo-stylus release from 0.10.3 onward needs rustc >= 1.91.0)
- Update `readme.md` install command, prerequisite line, and the two `rustup default 1.89` snippets to match

This is the coupled bump that PR #81 explicitly deferred ("A future bump will need to bump the rust toolchain and cargo-stylus together").

## Verification (wasm size measurement)

The only Stylus contract in this repo is `packages/stylus/contracts/your-contract`. Measured locally with `cargo stylus check` (rustc 1.91.0, cargo-stylus 0.10.8, from this branch's checked-out state — the network-dependent activation step was expected to fail since no local devnode was running, but the size check itself runs before that and printed cleanly):

| Toolchain | cargo-stylus | Contract size |
|---|---|---|
| 1.89.0 (baseline, pre-upgrade) | n/a (size unaffected by CLI version) | 20.8 KB (20,756 bytes) |
| 1.91.0 (this branch) | 0.10.8 | 20.9 KB (20,856 bytes) |

Delta: +100 bytes (+0.48%). Both are well under the 24 KB (24,576 byte) on-chain program size limit, with ~3.7 KB / ~15% headroom remaining on the new toolchain.

## Test plan
- [x] `cargo stylus check` run locally against `your-contract` on both rustc 1.89.0 and 1.91.0 to compare wasm size
- [x] Confirmed no other Stylus contract packages exist in the repo needing measurement
- [ ] CI (lint/demo workflows) passes with cargo-stylus 0.10.8 install