### PR TITLE
fix(web3): gate ENS resolution off local devnode; extend e2e to homepage

### DIFF
--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -452,6 +452,12 @@ in order:
    across the page-forward click. This is the regression check
    `useFetchBlocks.ts`/`app/blockexplorer/**` exist for (hand-ported from
    upstream in `351a34a`, never previously run against a live devnode).
+9. Navigate to `/` (the homepage) and wait for it to render. No new hard
+   assertion beyond that — this step exists purely for console/overlay
+   coverage. The burner wallet is already connected by this point, so the
+   homepage's `<Address address={connectedAddress} />` renders for real,
+   unlike `/debug` and `/blockexplorer` which never show it; this is the
+   page where a connected address's ENS name/avatar lookups actually fire.
 
 Every interactive element the script drives has an additive
 `data-testid` (see "data-testid surface" below) — the script does not
@@ -529,6 +535,20 @@ main PASS/FAIL:
   verdict came back PASS, FAIL, or the run crashed partway through —
   "prominent, never silent" means every exit path prints it.
 
+Signature rule (see the comment above `KNOWN_OVERLAY_ISSUES` in
+`browser-e2e.mjs`): match on something that identifies the CODEPATH — a
+calling hook/component name, or an application-level error-message prefix
+— never on a bare third-party hostname alone. A shared host (a public RPC,
+a demo API key) can be hit by more than one unrelated feature; a bare-host
+match silently absorbs every future codepath that happens to hit the same
+host under one old "accepted" reason. This baseline used to carry a
+public-RPC-CORS entry attributed to the (now-removed) native-currency
+price fetch, matched on the bare `eth.merkle.io` / shared-Alchemy-key
+hostnames — an unrelated ENS lookup (`Address.tsx`) hit the same hosts and
+matched right through it unnoticed, until the price feature that
+"explained" the entry was deleted and the entry had to be re-diagnosed
+from scratch. Don't repeat that: name the codepath in the `match` string.
+
 Seeded baseline (as of 2026-07-21, all confirmed to reproduce identically
 on `origin/main` — i.e. pre-existing, not caused by any change that
 introduced this check):
@@ -547,14 +567,13 @@ introduced this check):
   which logs a "Lit is in dev mode" notice whenever it isn't built for
   production — third-party, dev-only, no production impact.
   Does not appear in the dev-overlay badge, console warning only.
-- **Public-RPC CORS failures for the native-currency price fetch** —
-  `fetchPriceFromUniswap.ts` tries the scaffold's shared public demo
-  Alchemy key first, then falls back to the public RPC `eth.merkle.io`;
-  both now reject the browser's cross-origin `eth_call` with a CORS
-  preflight failure. The code catches this and falls back to a price of
-  0 — no crash, console/network noise only, and unrelated to the local
-  devnode chain this skill actually drives. Third-party (both endpoints'
-  CORS policy), pre-existing on `origin/main`.
+
+ENS name/avatar lookups (`Address.tsx`, `useEnsName`/`useEnsAvatar`) and
+RainbowKit's own internal ENS resolution for the connected account no
+longer appear here: both are now gated off when the target network is the
+local devnode (see `isLocalNetwork` in `Address.tsx` and
+`isLocalOnlyConfig` in `wagmiConfig.tsx`), so they don't fire — and don't
+need a baseline entry — while this skill runs.
 
 ### data-testid surface
 

--- a/.claude/skills/smoke-test/browser-e2e.mjs
+++ b/.claude/skills/smoke-test/browser-e2e.mjs
@@ -89,6 +89,19 @@ fs.mkdirSync(ARTIFACT_DIR, { recursive: true });
 // substring (never a full stack trace -- line numbers churn on every
 // dependency bump). Add an entry here, dated, with a one-line reason, once a
 // human has actually looked at a NEW issue and decided it's acceptable.
+//
+// Signature rule: match on something that identifies the CODEPATH (a calling
+// hook/component name, or an application-level error-message prefix), never
+// on a bare third-party hostname by itself. A shared host like a public RPC
+// or a demo API key can be hit by more than one unrelated feature; a bare-
+// host match silently absorbs every future codepath that happens to hit the
+// same host under one old, unrelated "accepted" reason, and a regression in
+// a brand-new feature would then read as KNOWN instead of NEW. Case in
+// point: an earlier version of this baseline matched bare "eth.merkle.io" /
+// the shared Alchemy demo key host, accepted as a price-fetch fallback --
+// then a completely unrelated ENS lookup (Address.tsx) started hitting the
+// exact same hosts and matched right through it, unnoticed, until the price
+// feature that "explained" the entry was deleted.
 const KNOWN_OVERLAY_ISSUES = [
   {
     match: "Encountered a script tag while rendering React component",
@@ -111,40 +124,6 @@ const KNOWN_OVERLAY_ISSUES = [
       "library, which logs this notice whenever it isn't built in production mode -- a dev- " +
       "only self-check with no production impact. Does not appear in the dev-overlay badge, " +
       "console warning only.",
-  },
-  {
-    match: "eth.merkle.io",
-    acceptedDate: "2026-07-21",
-    reason:
-      "Third-party: fetchPriceFromUniswap.ts's viem client falls back to the public mainnet " +
-      "RPC eth.merkle.io once the Alchemy demo key below also fails, and that endpoint " +
-      "rejects the browser's cross-origin eth_call with a CORS preflight failure. Caught in " +
-      "code, falls back to a price of 0 -- no crash, console/network noise only, unrelated to " +
-      "the local devnode chain this skill actually drives. Confirmed pre-existing on " +
-      "origin/main (identical fetchPriceFromUniswap.ts); not caused by any change on this " +
-      "branch.",
-  },
-  {
-    match: "eth-mainnet.g.alchemy.com/v2/oKxs-03sij",
-    acceptedDate: "2026-07-21",
-    reason:
-      "Third-party: `oKxs-03sij-U_N0iOlrSsZFr29-IqbuF` is scaffold-eth-2's long-standing " +
-      "shared public demo Alchemy key (DEFAULT_ALCHEMY_API_KEY in scaffold.config.ts), used " +
-      "when no NEXT_PUBLIC_ALCHEMY_API_KEY is configured. That shared demo endpoint now " +
-      "rejects browser cross-origin calls with a CORS failure; the code falls back further " +
-      "to eth.merkle.io (see the entry above) and ultimately to a price of 0. Confirmed " +
-      "pre-existing on origin/main (identical scaffold.config.ts default key); not caused by " +
-      "any change on this branch.",
-  },
-  {
-    match: "useNativeCurrencyPrice - Error fetching",
-    acceptedDate: "2026-07-21",
-    reason:
-      "Same root cause as the two eth.merkle.io/Alchemy CORS entries above -- this is the " +
-      "application-level console.error once fetchPriceFromUniswap.ts's retries are fully " +
-      "exhausted. Timing-dependent: it only fires once viem gives up, which can land after " +
-      "this run's capture window closes, so it will not appear on every run -- that's " +
-      "expected, not a sign the baseline is stale.",
   },
 ];
 
@@ -779,6 +758,22 @@ async function main() {
   const explorerScreenshot = await screenshot(cdp, "blockexplorer-pagination");
   log(`Screenshot: ${explorerScreenshot}`);
 
+  // 8. Homepage -- console/overlay coverage only, no new hard assertion
+  // beyond "it rendered". The burner wallet is already connected by this
+  // point (step 4), so the homepage's <Address address={connectedAddress} />
+  // renders for real here, unlike /debug and /blockexplorer which never
+  // show it -- this is the page where the ENS name/avatar lookups in
+  // Address.tsx actually fire, and the whole reason that codepath went
+  // unseen by this script before.
+  await navigateAndWaitForLoad(cdp, `${FRONTEND_BASE}/`);
+  await waitFor(cdp, `document.body.textContent.includes("Scaffold-Stylus")`, {
+    timeoutMs: 30000,
+    description: "homepage rendered",
+  });
+  record("homepage-rendered", "PASS", "homepage loaded, console/overlay coverage collected");
+  const homepageScreenshot = await screenshot(cdp, "homepage");
+  log(`Screenshot: ${homepageScreenshot}`);
+
   // Dev-overlay/console advisory: best-effort DOM read, after the full flow
   // has run so the overlay has had every chance to have picked something up.
   // Failure here is caught, not thrown -- an advisory that can crash Step 7
@@ -797,7 +792,7 @@ async function main() {
   unsetState("chromeDebugPort");
   unsetState("chromeUserDataDir");
 
-  return { debugScreenshot, explorerScreenshot };
+  return { debugScreenshot, explorerScreenshot, homepageScreenshot };
 }
 
 async function killChromeGroup(pid) {
@@ -817,11 +812,11 @@ async function killChromeGroup(pid) {
 let chromeHandleForFailure = null;
 
 main()
-  .then(({ debugScreenshot, explorerScreenshot }) => {
+  .then(({ debugScreenshot, explorerScreenshot, homepageScreenshot }) => {
     console.log("");
     console.log("=== Step 7 results ===");
     for (const r of results) console.log(`${r.status}: ${r.name}${r.detail ? ` (${r.detail})` : ""}`);
-    console.log(`Screenshots: ${debugScreenshot}, ${explorerScreenshot}`);
+    console.log(`Screenshots: ${debugScreenshot}, ${explorerScreenshot}, ${homepageScreenshot}`);
     printDevOverlayAdvisory();
     console.log("RESULT: PASS");
     process.exit(0);

--- a/packages/nextjs/components/scaffold-eth/Address/Address.tsx
+++ b/packages/nextjs/components/scaffold-eth/Address/Address.tsx
@@ -7,7 +7,7 @@ import { normalize } from "viem/ens";
 import { useEnsAvatar, useEnsName } from "wagmi";
 import { BlockieAvatar } from "~~/components/scaffold-eth";
 import { useTargetNetwork } from "~~/hooks/scaffold-eth/useTargetNetwork";
-import { getBlockExplorerAddressLink } from "~~/utils/scaffold-stylus";
+import { arbitrumNitro, getBlockExplorerAddressLink } from "~~/utils/scaffold-stylus";
 
 const textSizeMap = {
   "3xs": "text-[10px]",
@@ -85,19 +85,22 @@ export const Address = ({
   const checkSumAddress = address ? getAddress(address) : undefined;
 
   const { targetNetwork } = useTargetNetwork();
+  // ENS only exists on mainnet; resolving it against a local/dev chain just spends the
+  // request against the public mainnet RPC and fails, so skip it there.
+  const isLocalNetwork = targetNetwork.id === arbitrumNitro.id;
 
   const { data: ens, isLoading: isEnsNameLoading } = useEnsName({
     address: checkSumAddress,
     chainId: 1,
     query: {
-      enabled: isAddress(checkSumAddress ?? ""),
+      enabled: isAddress(checkSumAddress ?? "") && !isLocalNetwork,
     },
   });
   const { data: ensAvatar } = useEnsAvatar({
     name: ens ? normalize(ens) : undefined,
     chainId: 1,
     query: {
-      enabled: Boolean(ens),
+      enabled: Boolean(ens) && !isLocalNetwork,
       gcTime: 30_000,
     },
   });

--- a/packages/nextjs/services/web3/wagmiConfig.tsx
+++ b/packages/nextjs/services/web3/wagmiConfig.tsx
@@ -7,10 +7,17 @@ import { arbitrumNitro, getAlchemyHttpUrl } from "~~/utils/scaffold-stylus";
 
 const { targetNetworks } = scaffoldConfig;
 
-// We always want to have mainnet enabled (ENS resolution, ETH price, etc). But only once.
-export const enabledChains = targetNetworks.find((network: Chain) => network.id === 1)
-  ? targetNetworks
-  : ([...targetNetworks, mainnet] as const);
+// We want mainnet enabled for ENS resolution, but only when a real network is actually in
+// play. If every target network is the local devnode, adding mainnet here would make wagmi
+// (and RainbowKit's own internal ENS lookups, which key off this same chain list) treat
+// mainnet as configured and start firing ENS requests against the public internet from a
+// pure local-dev session -- see Address.tsx's isLocalNetwork gate for the other half of this.
+const isLocalOnlyConfig = targetNetworks.every((network: Chain) => network.id === arbitrumNitro.id);
+
+export const enabledChains =
+  targetNetworks.find((network: Chain) => network.id === 1) || isLocalOnlyConfig
+    ? targetNetworks
+    : ([...targetNetworks, mainnet] as const);
 
 export const wagmiConfig = createConfig({
   chains: enabledChains,


### PR DESCRIPTION
## Summary

Three-part fix, done in order per the investigation below (each part depended on the previous one settling first):

1. **ENS lookups no longer fire against a local/dev chain.** `Address.tsx`'s `useEnsName`/`useEnsAvatar` and RainbowKit's own internal ENS resolution for the connected account (used to populate `account.displayName`/`account.ensAvatar` in the header) were both firing mainnet ENS lookups unconditionally — even when the target network is the local devnode — because `wagmiConfig.tsx` always appended `mainnet` to the wagmi chain list ("We always want to have mainnet enabled"). Both went out over the public internet and failed with CORS errors against `eth.merkle.io` and the shared demo Alchemy key. Gated both:
   - `Address.tsx`: skips its own ENS queries when `targetNetwork.id === arbitrumNitro.id`.
   - `wagmiConfig.tsx`: no longer adds `mainnet` to the chain list at all when every target network is the local devnode — this is also what silences RainbowKit's internal resolution, since it keys off the same wagmi chain list (`useConfig().chains`), not anything we can gate through a prop.
   - Real deployments (any target network other than the local devnode) are unaffected — ENS still resolves normally there. This is conditional, not a removal.
   - Checked upstream scaffold-eth-2 at the version this repo was forked from (tag `v0.0.37`, matches our `wagmiConfig.tsx` comment verbatim): it does **not** gate ENS by network either — it always fires and relies on the UI's graceful fallback to the raw address. Since upstream offers nothing to mirror, I followed this codebase's own existing convention for local-network detection (e.g. `useScaffoldEventHistory.ts`'s `selectedNetwork.id !== arbitrumNitro.id` check) instead of inventing something new.
   - Cost of the un-gated behavior: no hang, no crash — the UI degrades gracefully to the raw address either way. The actual cost was console/network noise that polluted the known-issues baseline and masked a real regression (see part 3).

2. **Extended the browser e2e to the homepage.** `.claude/skills/smoke-test/browser-e2e.mjs` never visited `/`, which is exactly why the ENS codepath went unseen. Added a homepage visit after the block-explorer check: navigates to `/`, waits on a real DOM condition (no fixed sleep), collects console/overlay output the same way every other step does, and adds no new hard content assertion beyond "it rendered". Documented as step 9 in `SKILL.md`.

3. **Corrected the known-issues baseline.** The `eth.merkle.io` / shared-Alchemy-demo-key / `useNativeCurrencyPrice` entries in `KNOWN_OVERLAY_ISSUES` were attributed to `fetchPriceFromUniswap.ts`, which PR #94 deleted. A live run on this branch's Uniswap-removal predecessor showed those entries were **not** actually dead — they were still firing, just from the ENS codepath, unrelated to the reason on file. After part 1's fix + part 2's homepage coverage, a clean end-to-end run (see below) confirms all three are now genuinely gone — removed rather than left with a stale, misleading reason. Also fixed the design flaw this exposed: matching a baseline entry on a bare hostname conflates every codepath that happens to share that host (a price fetch and an unrelated ENS lookup both matched `eth.merkle.io` under one "accepted" reason). Added a note in `browser-e2e.mjs` and `SKILL.md` explaining the rule: match on something that identifies the codepath (calling hook/component or app-level error prefix), never a bare host alone.

## Verify

- `yarn next:check-types` — **RAN and passed**.
- `yarn next:lint` — **RAN and passed** (2 pre-existing unrelated warnings: unused `FAUCET_ADDRESS` in `FaucetButton.tsx`, unused `isDarkMode` in `IntegerInput.tsx`).
- `yarn next:build` — **RAN and passed**.
- Full smoke test run end to end on this branch (clean devnode + fresh contract deploy):
  - Step 0 Preflight — RAN and passed.
  - Step 1 Gates — RAN and passed.
  - Step 2 Start devnode — RAN and passed.
  - Step 3 ArbOS assertion — RAN and passed (115).
  - Step 4 Deploy default contract — RAN and passed.
  - Step 5 Multi-fragment (>24KB) contract — **DID NOT RUN** — `npx create-stylus@latest ... --skip-git` fails with `ArgError: unknown or unexpected option: --skip-git` (the flag no longer exists in `create-stylus@latest`). This is a known, pre-existing tooling mismatch, not a regression from this change.
  - Step 6 Start frontend — RAN and passed.
  - Step 7 Browser e2e — RAN and passed. Verbatim results:
    ```
    === Step 7 results ===
    PASS: contract-rendered (write-function-form-setGreeting present)
    PASS: default-greeting ("Building Unstoppable Apps!!!")
    PASS: wallet-connected (auto-connected on load (burner wallet, no manual Connect needed))
    PASS: write-and-readback (greeting() == "smoke-test-1784640386426")
    PASS: blockexplorer-pagination (page 2 has no blank/duplicate rows vs page 1, despite continuous mining)
    PASS: homepage-rendered (homepage loaded, console/overlay coverage collected)
    Screenshots: debug-readback.png, blockexplorer-pagination.png, homepage.png

    === Dev-overlay / console advisory (ADVISORY ONLY -- does not affect the verdict above) ===
    KNOWN  [Console/error] (x3) Encountered a script tag while rendering React component...
    KNOWN  [Console/warning] (x3) Lit is in dev mode. Not recommended for production!...
    STALE baseline entry (accepted 2026-07-21, not observed this run) -- consider removing: "eth.merkle.io"
    STALE baseline entry (accepted 2026-07-21, not observed this run) -- consider removing: "eth-mainnet.g.alchemy.com/v2/oKxs-03sij"
    STALE baseline entry (accepted 2026-07-21, not observed this run) -- consider removing: "useNativeCurrencyPrice - Error fetching"
    Dev-overlay DOM check: nextjs-portal present=true, heading=Console Error
    RESULT: PASS
    ```
    (This run was captured with the pre-part-3 baseline still in place, specifically to prove the three entries are genuinely STALE — not observed even once, across /debug, /blockexplorer, and the new homepage visit — before removing them. Part 3's commit removes them based on this evidence.)
  - Step 8 Teardown — RAN and passed (`teardown.sh`, no arguments); confirmed clean tree, no leaked docker container, ports 8547/3000 free, no state file. (The auto-generated `packages/nextjs/next-env.d.ts` churn from `next dev` was reverted before committing — not part of this change.)
- Headline checks reconfirmed: ArbOS 115, deploy, write-and-readback, block explorer with zero shared transactions across pages under live mining — all passed on the clean run above.

## Constraints honored

- No internal orchestration vocabulary, no absolute `/Users/` paths, no other project names in anything under `.claude/`.
- No `data-testid` removed or renamed.
- `packages/stylus` untouched; no `cargo` command run directly (the smoke test's own `yarn deploy` step invokes `cargo stylus` internally, per the existing skill flow — no manual `cargo` invocation was added).
- No existing assertion weakened.