### PR TITLE
chore: skills and CI workflow updates (1/2)

### DIFF
--- a/.claude/skills/sibling-sync/SKILL.md
+++ b/.claude/skills/sibling-sync/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: sibling-sync
+description: Phase 2 — verify (and, where automation is missing or broken, specify updates for) the sibling repos that receive changes from the main scaffold project: create-stylus, create-stylus-extensions, and the docs repo. Use when asked to propagate a release, check whether siblings are in sync, or gate phase 2. Must not run until phase 1 (update-check) has merged AND the phase 1.5 smoke test has passed.
+---
+
+# Sibling Sync — Phase 2
+
+Verifies that changes merged to the main scaffold project have actually reached its three siblings —
+`create-stylus`, `create-stylus-extensions`, and `scaffold-stylus-docs` — each of which receives updates by a
+different mechanism, and specifies concrete updates where that mechanism is missing, broken, or stale.
+
+## Rule
+
+This skill **must not run** until:
+
+1. Phase 1 (`update-check`) findings are merged and released, and
+2. The phase 1.5 smoke test has passed on that release.
+
+Running phase 2 against an unmerged or unverified base produces a report about work that isn't real yet. The
+script's own **Gate** step re-checks readiness and aborts if phase 1 is not actually done — that gate is a
+backstop, not a substitute for checking this rule first.
+
+This skill is **read-only**: it never edits, commits, publishes, or upgrades anything in any repo. Its output
+is a per-sibling verdict and, where needed, a concrete update spec. Applying anything from that spec is a
+separate, delegated task.
+
+## Run it
+
+```
+Workflow({ scriptPath: ".claude/skills/sibling-sync/phase2-siblings.mjs" })
+```
+
+The script resolves the main repo path itself via `git rev-parse --show-toplevel` and derives the GitHub org
+from `git remote get-url origin` — it carries no absolute paths and works from any clone.
+
+## MODE_DISCOVERY — check vs. update
+
+Before verifying anything, each sibling agent must first decide, with evidence, whether working automation
+exists for that sibling:
+
+- ls the repo's `.github/workflows/` (or confirm `.github/` doesn't exist at all)
+- for each relevant workflow: `gh run list --workflow <file> --limit 5 --json conclusion,createdAt`
+- does its trigger still **resolve**? A workflow triggering on a branch that was deleted never fires again —
+  check with `git ls-remote --heads origin <trigger-branch>`
+- did it run **after** the main repo's most recent relevant merge, and did it **conclude success**?
+
+A workflow file existing is not proof of working automation. Zero runs, a last run predating the merge that
+matters, or a dead trigger all mean the automation is not doing the job.
+
+That decides the **mode**, recorded per sibling:
+
+- `mode = "check"` — working automation exists. The agent only verifies it actually ran and carried the right
+  content; it does not re-specify work the automation already does.
+- `mode = "update"` — no automation, or it's broken/dead/stale. The agent specifies the concrete update: exactly
+  which files must change, to what, and why — specific enough to execute without re-deriving the analysis.
+
+A sibling expected to be automated that turns out not to be is a **blocker finding** in its own right, separate
+from whatever content is stale.
+
+## What it checks — 3 parallel siblings
+
+| Sibling | Delivery mechanism | Urgency |
+|---|---|---|
+| `create-stylus` | Automatic: merge to main rsyncs into `templates/base` and runs `npm publish` | Reaches users on next publish |
+| `create-stylus-extensions` | Manual: each extension is a branch fetched as an overlay **at scaffold time**, no CI | Reaches users **immediately** — no publish step, no version to pin back to |
+| `scaffold-stylus-docs` | Manual, no PR-level CI | Misleads users but doesn't break builds |
+
+For `create-stylus`, verification checks propagation against real file diffs (not "looks synced"), confirms no
+maintainer tooling leaked into the **published npm tarball** (the exclude list is a claim, the tarball is the
+evidence), and checks version parity across the main repo, the sibling, and the npm dist-tags.
+
+For `create-stylus-extensions`, verification enumerates every extension branch and checks whether its overlay
+still applies cleanly to the updated base — a file an overlay replaces that the base has since restructured is
+the classic silent break. `chainlink-data-feed` is intentionally frontend-only with a no-op deploy script; that
+is not a bug.
+
+For `scaffold-stylus-docs`, verification greps for version numbers and commands that no longer match the repo,
+and distinguishes docs that are **wrong** (would mislead or break a user) from docs that are merely incomplete.
+
+## Reading the output
+
+The synthesis report ranks propagation failures first — a sibling where the main repo's changes never actually
+arrived, even though phase 1 merged — then ranks remaining findings by how fast they reach users, not by
+tidiness. Any leaked maintainer file in the published npm package is a blocker regardless of other severity.
+Every sibling's `mode` is reported alongside its verdict; a sibling in `update` mode with no findings is a
+contradiction the report should flag, not silently accept.
+
+## After the run
+
+1. Report the verdict per sibling, propagation failures first.
+2. Report each sibling's mode (`check` / `update`) alongside its verdict.
+3. For anything actionable, delegate the change or apply it as a separate task — this skill does not apply
+   changes.

--- a/.claude/skills/sibling-sync/phase2-siblings.mjs
+++ b/.claude/skills/sibling-sync/phase2-siblings.mjs
@@ -1,0 +1,263 @@
+export const meta = {
+  name: 'sibling-sync-phase2',
+  description: 'Phase 2 — verify and update siblings after the main scaffold repo has been updated and merged',
+  whenToUse: 'Only after phase 1 (update-check) is green AND its PRs are merged and released. Aborts if the base is not ready.',
+  phases: [
+    { title: 'Gate', detail: 'confirm the main repo is merged and released — abort if not' },
+    { title: 'Verify', detail: 'parallel: create-stylus propagation, extension overlays, docs accuracy' },
+    { title: 'Report', detail: 'per-sibling plan, propagation failures first' },
+  ],
+}
+
+const PREAMBLE = `Resolve the MAIN repo path yourself:
+  git rev-parse --show-toplevel
+Siblings live alongside it. Derive the GitHub org from 'git remote get-url origin' rather than assuming.
+Do NOT hardcode any absolute path.
+
+READ-ONLY. Do not edit, commit, publish, or upgrade anything in any repo. Report only.`
+
+const MODE_DISCOVERY = `STEP 0 — DECIDE THE MODE. Do this FIRST; it determines what the rest of your work is.
+
+Ask: does this sibling have WORKING automation that propagates changes from the main repo?
+Answer with EVIDENCE, never by assumption and never from a filename:
+  - ls the repo's .github/workflows/ (or confirm .github/ does not exist at all)
+  - for each relevant workflow: gh run list --workflow <file> --limit 5 --json conclusion,createdAt
+  - does its trigger still RESOLVE? A workflow triggering on a branch that was deleted never fires again.
+    Check with: git ls-remote --heads origin <trigger-branch>
+  - did it run AFTER the main repo's most recent relevant merge, and did it CONCLUDE success?
+
+A workflow FILE existing is NOT proof of working automation. Zero runs, or a last run predating the merge you
+care about, or a dead trigger, all mean the automation is NOT doing the job.
+
+Then set mode:
+  mode = "check"  -> working automation exists. Your job is ONLY to verify it actually ran and actually carried
+                     the right CONTENT. Do not re-specify work the automation already does.
+  mode = "update" -> no automation, or it is broken/dead/stale. Your job is to specify the CONCRETE UPDATE:
+                     exactly which files must change, to what, and why. Be specific enough that someone can
+                     execute it without re-deriving your analysis. Name real paths and real values.
+
+Record your evidence in the "automation" field. If a sibling you expected to be automated turns out NOT to be,
+that is a BLOCKER finding in its own right, separate from whatever content is stale.
+
+`
+
+const HONESTY = `
+SCANNER HONESTY — classify EVERY result as exactly one of these, and never conflate them:
+  (a) check RAN and is clean
+  (b) check DID NOT RUN — tool missing, permission denied, endpoint failed, repo unreachable
+  (c) issue found but NOT actually reachable by users
+State (b) explicitly with severity "unchecked". A sibling you could not verify is UNCHECKED, not passing.
+Absence of a red signal is not presence of a green one.`
+
+const RESULT = {
+  type: 'object', additionalProperties: false, required: ['sibling', 'status', 'mode', 'findings'],
+  properties: {
+    sibling: { type: 'string' },
+    status: { enum: ['in-sync', 'needs-update', 'broken', 'unchecked'] },
+    mode: { enum: ['check', 'update'], description: 'Set per MODE_DISCOVERY — check (working automation exists) or update (no automation, or broken/dead/stale)' },
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object', additionalProperties: false,
+        required: ['title', 'severity', 'evidence', 'reaches_users', 'action'],
+        properties: {
+          title: { type: 'string' },
+          severity: { enum: ['blocker', 'needs-update', 'nice-to-have', 'informational', 'unchecked'] },
+          evidence: { type: 'string', description: 'Actual command output or file content proving this — not an inference' },
+          reaches_users: { type: 'string', description: 'How and how fast this reaches an end user, or "does not"' },
+          action: { type: 'string' },
+        },
+      },
+    },
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2 is meaningless on an unmerged base.
+// ---------------------------------------------------------------------------
+
+phase('Gate')
+
+const GATE = {
+  type: 'object', additionalProperties: false, required: ['ready', 'reason', 'mainVersion', 'npmVersion'],
+  properties: {
+    ready: { type: 'boolean' },
+    reason: { type: 'string', description: 'If not ready, exactly what is missing' },
+    mainVersion: { type: 'string' },
+    npmVersion: { type: 'string' },
+  },
+}
+
+const gate = await agent(
+  `${PREAMBLE}
+
+Determine whether PHASE 1 IS DONE, so phase 2 can safely run. Be strict — a false "ready" wastes the whole run.
+
+Check and report ACTUAL output:
+1. git status -sb on the main repo — is main clean and in sync with origin/main?
+2. gh pr list --state open — are there still open PRs carrying phase-1 work (dependency, gitignore, devnode, or
+   security fixes)? Unmerged phase-1 work means NOT ready.
+3. git log origin/main --oneline -10 — did the phase-1 changes actually land on main?
+4. The version in the main repo's package.json.
+5. npm view create-stylus version — the published version.
+6. gh run list --workflow release-create-stylus.yaml --limit 3 — did the release pipeline run and SUCCEED after
+   the most recent merge? Read the conclusion, do not assume.
+
+ready = true ONLY if: main is clean and synced, no phase-1 PR is still open, the changes are visibly on main,
+and the release pipeline succeeded after them.
+
+If versions disagree between the repo and npm, that alone is NOT necessarily a blocker (a release may still be
+in flight) — but say so clearly in the reason.
+${HONESTY}`,
+  { label: 'gate:phase1-ready', phase: 'Gate', schema: GATE }
+)
+
+if (!gate || !gate.ready) {
+  log(`ABORTED — phase 1 is not done: ${gate ? gate.reason : 'gate check returned nothing'}`)
+  return {
+    aborted: true,
+    reason: gate ? gate.reason : 'gate check returned nothing',
+    hint: 'Finish and merge phase 1 (update-check) first. Do not work around this gate.',
+    gate,
+  }
+}
+
+log(`Gate passed — main ${gate.mainVersion}, npm ${gate.npmVersion}. Proceeding to siblings.`)
+
+// ---------------------------------------------------------------------------
+// Each sibling receives changes by a DIFFERENT mechanism, so each gets a
+// different check. Do not collapse these into one generic "is it updated" pass.
+// ---------------------------------------------------------------------------
+
+phase('Verify')
+
+const SIBLINGS = [
+  {
+    key: 'create-stylus',
+    prompt: `${PREAMBLE}
+
+${MODE_DISCOVERY}
+Sibling: create-stylus. It receives changes AUTOMATICALLY — merging to the main repo's main branch rsyncs the
+repo into create-stylus/templates/base and then runs 'npm publish'. Your job is to verify the propagation
+actually happened and carried the right content, NOT merely that the workflow reported success.
+
+1. PROPAGATION IS REAL. Pick several files that phase 1 changed in the main repo and diff them against the
+   same paths under create-stylus templates/base (use the local clone if present, otherwise gh api to read the
+   file). Report concrete content differences, not "looks synced".
+
+2. NOTHING LEAKED. The rsync excludes .claude/ and .worktrees/, but verify against the ACTUAL PUBLISHED
+   PACKAGE rather than the exclude list — the exclude list is a claim, the tarball is the evidence:
+     npm pack create-stylus@latest --dry-run --json    (or download and list the tarball contents)
+   Confirm NO .claude/, .worktrees/, .git/, or other maintainer tooling is present. If any is, that is a
+   BLOCKER — it means the exclusions do not work and maintainer files are on every user's disk.
+
+3. VERSION PARITY. main repo package.json vs create-stylus main package.json vs 'npm view create-stylus version'
+   and the dist-tags. All three should agree.
+
+4. STALE CONTENT. Is templates/base missing anything the main repo has, or carrying anything the main repo
+   deleted? Deletions are the common miss — rsync --delete should handle it, verify it did.
+
+For each finding say how and how fast it reaches an end user: create-stylus is npm-published, so a bad sync
+reaches anyone running 'npx create-stylus' after the publish.
+${HONESTY}`,
+  },
+  {
+    key: 'create-stylus-extensions',
+    prompt: `${PREAMBLE}
+
+${MODE_DISCOVERY}
+Sibling: create-stylus-extensions. This one is the URGENT one. Extensions are NOT npm published — each
+extension is a branch whose overlay is fetched AT SCAFFOLD TIME. So a broken overlay reaches users
+IMMEDIATELY, with no publish step in between and no version to pin back to.
+
+Also note: this repo has NO CI at all (no .github/). Verify that claim yourself. If true, your check is the
+only gate that exists.
+
+1. ENUMERATE the extension branches: gh api repos/{org}/create-stylus-extensions/branches --paginate
+   (derive {org} from the main repo's remote). List every extension branch and when it was last updated.
+
+2. OVERLAY COMPATIBILITY WITH THE NEW BASE. This is the core question. For each extension, determine whether
+   its overlay still applies cleanly to the UPDATED base:
+   - which files does the overlay replace or add?
+   - do those files still exist in the new base with a compatible shape?
+   - does the overlay reference anything phase 1 changed (paths, versions, config keys, deploy script
+     structure, workspace layout)?
+   A file the overlay overwrites that the base has since RESTRUCTURED is the classic silent break.
+
+3. KNOWN CONTEXT you must respect: chainlink-data-feed is INTENTIONALLY frontend-only — it reads an existing
+   on-chain feed via externalContracts.ts and has no contract of its own. Its deploy script is a deliberate
+   no-op. Do NOT report that as broken.
+
+4. STALENESS. Any extension branch far behind the base is a risk even if it still applies. Report age.
+
+Prefer real evidence: read the actual overlay files and the actual base files and compare. Do not infer from
+branch names or commit messages.
+${HONESTY}`,
+  },
+  {
+    key: 'scaffold-stylus-docs',
+    prompt: `${PREAMBLE}
+
+${MODE_DISCOVERY}
+Sibling: scaffold-stylus-docs. It receives changes MANUALLY — nobody syncs it, so it drifts silently. It has
+NO PR-level CI (verify this), so nothing catches inaccuracy.
+
+Your job: find places where the docs now describe behaviour the code no longer has.
+
+1. VERSION AND COMMAND ACCURACY. Grep the docs for version numbers and shell commands (cargo-stylus versions,
+   node/yarn/npm commands, rust toolchain versions, install instructions) and check each against what the main
+   repo actually specifies now. A documented version that no longer matches the repo is a finding.
+
+2. PHASE 1 CHANGES REFLECTED. Whatever phase 1 changed in the main repo — determine whether the docs needed to
+   change too, and whether they did. Read the main repo's recent main-branch commits to know what changed.
+
+3. NEW BEHAVIOUR UNDOCUMENTED. Anything the scaffold now does that the docs never mention. Prior known gap:
+   the ArbOS 60 / nitro-node v3.11.0 devnode requirement for contracts over 24KB — check whether that is now
+   documented (a PR may have landed it) rather than assuming either way.
+
+4. INSTRUCTIONS THAT WOULD NOW FAIL. The highest-value finding: a documented command that would error if a user
+   copy-pasted it today. Check install steps and deploy steps especially.
+
+Distinguish clearly between docs that are WRONG (would mislead or break a user) and docs that are merely
+INCOMPLETE. Only the first is urgent.
+${HONESTY}`,
+  },
+]
+
+const results = (await parallel(
+  SIBLINGS.map((s) => () =>
+    agent(s.prompt, { label: `sibling:${s.key}`, phase: 'Verify', schema: RESULT })
+  )
+)).filter(Boolean)
+
+if (results.length < SIBLINGS.length) {
+  log(`WARNING: ${SIBLINGS.length - results.length} sibling(s) returned nothing — coverage incomplete`)
+}
+
+phase('Report')
+
+const report = await agent(
+  `Synthesize a phase-2 sibling report. Base state: main repo ${gate.mainVersion}, npm ${gate.npmVersion}.
+
+${JSON.stringify(results, null, 2)}
+
+Produce a decision-ready report:
+1. One-sentence verdict per sibling: in-sync / needs-update / broken / unchecked.
+2. THE MODE per sibling — "check" (working automation, only verified) or "update" (no automation, or
+   broken/dead/stale, so a concrete update was specified). Report this alongside the verdict; a sibling in
+   "update" mode with no findings is a contradiction, flag it.
+3. PROPAGATION FAILURES FIRST — anything where the main repo's changes did not actually reach a sibling. These
+   outrank everything else, because they mean the phase-1 work is not live even though it merged.
+4. Then rank by HOW FAST IT REACHES USERS, not by tidiness:
+   - create-stylus-extensions overlays reach users IMMEDIATELY (fetched at scaffold time, no publish, no pin)
+   - create-stylus reaches users on the next npm publish
+   - docs mislead users but do not break builds
+5. Any leaked maintainer file in the published npm package is a BLOCKER regardless of other severity.
+6. List explicitly what was verified CLEAN and what was UNCHECKED. Never let an unchecked sibling read as passing.
+7. For each action, say whether it is a CODE change (needs to be delegated as a separate task) or an OPS action.
+
+Be blunt. If the siblings are genuinely in sync, say so plainly and do not manufacture work.`,
+  { label: 'synthesize', phase: 'Report', schema: RESULT }
+)
+
+return { phase: 2, gate, siblings: results.map((r) => ({ sibling: r.sibling, status: r.status, mode: r.mode })), report }

--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -1,0 +1,976 @@
+---
+name: smoke-test
+description: Use when validating scaffold-stylus after update-check (phase 1) upgrades are merged and before sibling-sync (phase 2) propagates them, to confirm the devnode -> deploy -> ABI export -> scaffold hooks -> tx signing -> read-back chain still works end to end. Triggers on requests to smoke-test, phase 1.5, or gate sibling-sync.
+---
+
+# Smoke Test (Phase 1.5)
+
+## Overview
+
+This is the Phase 1.5 gate between `update-check` (Phase 1, dependency
+audit/upgrade) and `sibling-sync` (Phase 2, propagation to `create-stylus`,
+`create-stylus-extensions`, and `docs`). Phase 1 upgrades touch Rust/Node
+toolchains and dependency versions that `cargo stylus check`, `yarn`, and CI
+alone cannot fully validate — they don't prove a contract still *activates*
+on the local devnode, that its ABI still reaches the frontend, or that a
+burner-wallet transaction still round-trips. This skill runs that full
+chain for real and reports a verdict that gates whether Phase 2 is allowed
+to proceed.
+
+**READ-ONLY CONTRACT:** This skill is STRICTLY READ-ONLY with respect to
+committed repository source. It runs the stack, deploys throwaway
+contracts, and drives a browser — it MUST NOT edit `.rs`, `.ts`, `.tsx`,
+`.toml`, or any other tracked source file to make a failing step pass.
+If a step fails, report it as failed; do not "fix" it by editing code.
+The only tracked files this skill's own steps are permitted to touch are
+build artifacts it restores on a PASS in Step 8 (`deployedContracts.ts`)
+— see that step for the exact restore command. On FAIL/INCONCLUSIVE, Step
+8 deliberately leaves this file modified — it is debugging evidence, not
+a READ-ONLY violation; it gets restored the next time teardown actually
+runs. The one standing exception is the additive `data-testid` attributes
+Step 7's browser automation drives (see that step's "data-testid surface"
+table) — pure attribute additions with no logic/render change, added once
+as a one-time scope decision, not something a run of this skill edits.
+
+## Ordering Contract
+
+1. `update-check` (Phase 1) — audits and upgrades dependencies.
+2. Phase 1 upgrade PR(s) are merged to `main`.
+3. **`smoke-test` (Phase 1.5) — you are here.** Validates the merged
+   upgrades against the real stack.
+4. `sibling-sync` (Phase 2) — propagates the validated state to sibling
+   repos. **Only runs if this skill's verdict is PASS.**
+
+## Non-Negotiable Reporting Rule (tri-state)
+
+Copy this rule verbatim in behavior from `update-check` and `sibling-sync`:
+every step below reports **exactly one** of three states — never two,
+never a blend:
+
+- **(a) RAN and passed** — the command executed and its concrete assertion
+  held.
+- **(b) DID NOT RUN** — a tool was missing, a port was busy, an env var
+  was absent, or the step timed out waiting on something external. **(b)
+  is not a pass.** It means the step gives no evidence either way.
+- **(c) RAN and failed** — the command executed and its assertion did not
+  hold, or the command exited non-zero for a reason other than a missing
+  prerequisite.
+
+**Verdict:**
+- **PASS** — every required step (1 through 7) is (a).
+- **INCONCLUSIVE** — any step is (b). Fix the missing prerequisite and
+  re-run; do not treat INCONCLUSIVE as "probably fine."
+- **FAIL** — any step is (c).
+
+Neither INCONCLUSIVE nor FAIL opens the Phase 2 (`sibling-sync`) gate.
+Step 8 (teardown) is not itself part of the PASS/INCONCLUSIVE/FAIL
+calculation, but whether it *runs at all* now depends on that verdict —
+see Step 8: full teardown only happens on PASS; on FAIL, INCONCLUSIVE, or
+a crash partway through, the live state is deliberately left running
+instead. When teardown does run, a teardown failure must still be
+reported, since a leaked devnode poisons the next run.
+
+Step 9 (Sepolia deploy) is likewise excluded from this calculation — it is
+opt-in, off by default, and reports its own **SKIPPED / PASS / FAIL**
+independently of Steps 1–7. A SKIPPED Step 9 never blocks the Phase 2 gate
+and must never be folded into the overall verdict as a silent pass; see
+Step 9.
+
+## Step 0 — Preflight
+
+```bash
+./.claude/skills/smoke-test/preflight.sh
+```
+
+Checks (in order): `node`, `yarn`, `docker` binary + daemon reachability
+(`docker info`), `cast` (Foundry), `cargo`, `cargo stylus`, the
+`SMOKE_TEST_CONFIRM` consent gate and the `packages/stylus/.env`
+deploy-credentials gate (see Step 1), that the fixed RPC port 8547 is free
+(see "DO NOT make port 8547 dynamic" below), and that no artifact from a
+prior unclean run is already sitting in the working tree
+(`packages/nextjs/contracts/deployedContracts.ts`,
+`packages/stylus/deployments`, `packages/stylus/contracts/erc20-example`).
+
+Port 3000 is arbitrary, not fixed, so a busy 3000 does not abort the run:
+preflight instead probes upward from 3000 (3000, 3001, ... capped at 20
+attempts) for the first free port, and prints it as `FRONTEND_PORT=<port>`
+on the last line of output when it exits 0. A busy 3000 is often a dev
+server leaked from a prior smoke-test run, so the probe does not skip
+silently — for every occupied port it names the holder's PID and full
+command (via `lsof`/`ps`, never killing it) before trying the next one, so
+a leak from this repo's own `next dev` stays visible instead of being
+routed around. The final chosen port is echoed prominently
+(`>>> FRONTEND_PORT=<port> <<<`) so it isn't buried in the rest of the
+preflight output. Capture the value and export it for the rest of the run:
+
+```bash
+export FRONTEND_PORT=<value printed by preflight.sh>
+```
+
+Every downstream step that needs the frontend port — Step 6's launch and
+readiness poll, Step 7's browser navigation — uses `$FRONTEND_PORT`, never
+a hardcoded `3000`. Report the chosen port in the run's final output.
+
+- Exit 0 → proceed to Step 2, using the printed `FRONTEND_PORT`.
+- Exit 1 (missing tool), 3 (RPC port 8547 busy), 4 (dirty tree from a
+  leaked prior run), or 6 (no free frontend port found in the probed
+  range) → **(b) DID NOT RUN** for every downstream step; stop here.
+- Exit 2 (consent gate closed) or 5 (deploy-credentials gate closed) →
+  see Step 1; **(b) DID NOT RUN** for the whole run.
+
+## Step 1 — Gates (two, both required)
+
+Two distinct, independent gates must both pass before Step 2 starts the
+devnode. Neither is optional and neither substitutes for the other.
+
+### Step 1a — Consent gate
+
+Explicit opt-in is required before this skill touches anything:
+
+```bash
+export SMOKE_TEST_CONFIRM=1
+```
+
+**Why a gate:** this skill binds host port 8547 and a frontend port
+(probed from 3000 upward), runs a Docker container, deploys real (if
+throwaway) contracts, and drives a live browser session with a burner
+wallet. It must never fire as a silent side effect of another skill or an
+automated loop.
+
+- `SMOKE_TEST_CONFIRM` set → **(a)**, proceed.
+- Unset → **(b) DID NOT RUN — env absent.** Tell the caller to set it and
+  stop; do not assume consent.
+
+### Step 1b — Deploy-credentials gate
+
+`yarn deploy` (Step 4) reads its devnet `ACCOUNT_ADDRESS` / `RPC_URL` /
+`PRIVATE_KEY` from `packages/stylus/.env`. That file does not exist in a
+fresh clone, and `packages/stylus/.env.example` ships its entire `##
+devnet` block commented out (only `DEPLOYMENT_DIR=` is uncommented, and
+it's blank). Without this gate, Step 4 dies on a missing/blank value
+*after* Step 2 has already bound ports and started Docker — check this
+**before** Step 2, not after.
+
+`preflight.sh` checks that `packages/stylus/.env` exists and has
+non-blank, uncommented `ACCOUNT_ADDRESS=`, `RPC_URL=`, and `PRIVATE_KEY=`
+lines. It never reads the rest of the file's contents back to the
+terminal (that file may also hold real sepolia/mainnet secrets in other
+blocks) and it never creates or edits the file itself.
+
+- All three devnet keys present and non-blank → **(a)**, proceed.
+- File missing, or any of the three keys missing/blank → **(b) DID NOT
+  RUN — env absent.** Halt and ask a human to create/edit
+  `packages/stylus/.env` with this exact block — these are the
+  nitro-devnode's own well-known prefunded dev values (the private key is
+  hardcoded in plaintext at `nitro-devnode/run-dev-node.sh` line 7), not a
+  secret to invent or protect:
+
+  ```
+  DEPLOYMENT_DIR=deployments
+
+  ## devnet
+  ACCOUNT_ADDRESS=0x3f1Eae7D46d88F08fc2F8ed27FCb2AB183EB2d0E
+  RPC_URL=http://127.0.0.1:8547
+  PRIVATE_KEY=0xb6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659
+  ```
+
+  Never auto-write this block into `.env` on the human's behalf, never
+  invent or guess different values, and never echo back any *other*
+  content already in the file (it may contain real secrets for other
+  networks).
+
+## Step 2 — Start the devnode
+
+```bash
+CHAIN_LOG=$(mktemp -t smoke-test-chain.XXXXXX.log)
+CHAIN_PID=$(node .claude/skills/smoke-test/launch-detached.mjs "$CHAIN_LOG" ./nitro-devnode/start-chain-with-cors.sh)
+node .claude/skills/smoke-test/state.mjs set chainPid "$CHAIN_PID"
+```
+
+Launched via `launch-detached.mjs`, not a plain `cmd &`: the devnode
+process is detached from this shell/session (Node's `spawn({detached:
+true})` calls `setsid(2)` directly, so it survives the session that
+started it — e.g. the invoking shell or session being closed — the same way
+a leaked container used to outlive a killed shell but the wrapper script
+around it didn't). Its PID is recorded in the shared state file
+(`.claude/skills/smoke-test/.smoke-state.json`, via `state.mjs`) rather
+than only living in this shell's `$CHAIN_PID` variable, so Step 8's
+teardown (and a human's escape hatch, on FAIL) can find and kill it even
+from a fresh shell. See "Detached processes and the state file" below Step
+8 for the full rationale.
+
+This runs `nitro-devnode/start-chain-with-cors.sh`, which `docker run
+--name nitro-dev -p 8547:8547 ...`, waits for the RPC, calls
+`becomeChainOwner()`, and (as of the ArbOS-60 fix) schedules the ArbOS 60
+upgrade itself. Do not schedule it again here — Step 3 only *verifies* it
+landed.
+
+Assertion — poll until the RPC answers, capped at 90s. Uses `$SECONDS`
+(a bash/zsh builtin) for the bound instead of GNU coreutils `timeout`,
+which is not present on stock macOS:
+
+```bash
+deadline=$((SECONDS + 90))
+until curl -s -X POST -H "Content-Type: application/json" \
+    --data '{"jsonrpc":"2.0","method":"net_version","params":[],"id":1}' \
+    http://127.0.0.1:8547 | grep -q result; do
+  if [ "$SECONDS" -ge "$deadline" ]; then
+    echo "timed out waiting for devnode RPC" >&2
+    exit 1
+  fi
+  sleep 1
+done
+```
+
+- `docker` fails to pull/start the image (daemon issue, network issue) →
+  **(b) DID NOT RUN — devnode failed to boot** (external/environmental,
+  not a code regression).
+- Image starts but the RPC never answers within 90s, or the container
+  exits, or `becomeChainOwner()`/CREATE2-factory/Cache-Manager/
+  StylusDeployer setup inside the script errors out → **(c) RAN and
+  failed** (this is the stack itself misbehaving — a real regression
+  candidate).
+- RPC answers within the timeout → **(a)**.
+
+## Step 3 — ArbOS Assertion (regression gate for the multi-fragment fix)
+
+This directly re-checks the fix landed in `db5dfcf` / PR #80: the dev node
+boots at ArbOS 59 and must be moved to ArbOS 60, or every >24KB
+(multi-fragment) Stylus contract will revert on activation.
+
+```bash
+cast call --rpc-url http://127.0.0.1:8547 \
+  0x0000000000000000000000000000000000000064 \
+  "arbOSVersion()(uint64)"
+```
+
+Assertion: output must be **115** (55 + ArbOS 60). `114` means the chain
+is stuck at ArbOS 59.
+
+- `cast` errors (RPC unreachable) → **(b) DID NOT RUN** (Step 2 already
+  should have caught this; treat as devnode instability).
+- Output is `114` → **(c) RAN and failed — devnode stuck at ArbOS 59;
+  multi-fragment deploys will revert.** This is a real regression: it
+  means `nitro-devnode/start-chain-with-cors.sh`'s
+  `scheduleArbOSUpgrade(60, 0)` call regressed or the pinned image
+  (`NITRO_NODE_VERSION` in that script) was downgraded below v3.10.0.
+- Output is `115` → **(a)**.
+
+## Step 4 — Deploy the default contract (deploy -> ABI export -> scaffold hooks)
+
+```bash
+yarn deploy
+```
+
+This runs `cargo stylus deploy` against `packages/stylus/contracts/
+your-contract`, then automatically runs `cargo stylus export-abi` and
+writes the address/ABI into `packages/nextjs/contracts/
+deployedContracts.ts` (chain id `412346`) — the file the Next.js scaffold
+hooks (`useScaffoldReadContract`/`useScaffoldWriteContract`) read from.
+
+Assertion — all three must hold:
+
+```bash
+test -f packages/stylus/deployments/412346_latest.json
+grep -q '"your-contract"' packages/nextjs/contracts/deployedContracts.ts
+grep -q '412346' packages/nextjs/contracts/deployedContracts.ts
+```
+
+- `yarn` itself missing, or `.env`/network resolution errors before any
+  RPC call is attempted → **(b) DID NOT RUN**.
+- `cargo stylus deploy` exits non-zero, or exits 0 but
+  `deployedContracts.ts` doesn't contain the new entry (export-abi step
+  silently failed) → **(c) RAN and failed**.
+- All three checks pass → **(a)**.
+
+## Step 5 — Deploy a >24KB (multi-fragment) contract
+
+This is the end-to-end proof for Step 3's regression gate: an ArbOS
+report of 115 is meaningless if a real multi-fragment contract still
+reverts. Reuse the exact contract type PR #80 verified (25.1KB / 2
+fragments) by scaffolding it fresh from `create-stylus` rather than hand-
+authoring new Rust for this skill:
+
+```bash
+npx create-stylus@latest smoke-fixture -e erc-20 --skip-install --skip-git
+cp -r smoke-fixture/packages/stylus/contracts/erc20-example \
+  packages/stylus/contracts/erc20-example
+rm -rf smoke-fixture
+```
+
+`packages/stylus/contracts/` is a Cargo workspace with `members = ["*"]`
+(see `packages/stylus/contracts/Cargo.toml`), so the copied crate joins
+the workspace automatically — no `Cargo.toml` edit needed. This directory
+is skill-owned scratch, not repo source; it must never be `git add`ed. On
+PASS it is deleted in Step 8; on FAIL/INCONCLUSIVE it is deliberately left
+in place as debugging evidence until `teardown.sh` is run by hand.
+
+```bash
+cd packages/stylus/contracts/erc20-example
+cargo stylus check --endpoint http://127.0.0.1:8547
+cargo stylus deploy --endpoint http://127.0.0.1:8547 \
+  --private-key 0xb6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659 \
+  --no-verify
+cd -
+```
+
+(The private key is the nitro-devnode's well-known prefunded dev account,
+the same one `nitro-devnode/start-chain-with-cors.sh` uses — not a secret.)
+
+**Use `cargo stylus check` to measure/validate the contract. Do NOT use
+plain `cargo build`.** `cargo build` fails on the host target for this
+contract (and for `your-contract`) because of a known
+`openzeppelin-stylus 0.3.0` / `stylus-sdk 0.9.0` VM mismatch — it is
+**expected and pre-existing**, not a regression, and not caused by any
+toolchain upgrade. A rustc 1.89 -> 1.91 bump is in flight on another
+branch right now; if you run `cargo build` here and hit this failure, do
+not attribute it to that upgrade and do not report it as a bug to fix —
+`cargo stylus check` (which builds for `wasm32-unknown-unknown`, not the
+host) is the correct command and does not hit this mismatch.
+
+Assertion: `cargo stylus check` reports a WASM size over 24576 bytes /
+2+ activation fragments, and `cargo stylus deploy` completes with a
+receipt status of 1 (no `execution reverted`).
+
+- `npx create-stylus@latest` fails to fetch (network/npm registry issue)
+  → **(b) DID NOT RUN**.
+- The fetched fixture is under 24KB / 1 fragment (upstream template
+  shrank) → **(b) DID NOT RUN — fixture no longer exceeds the
+  multi-fragment threshold; this step proves nothing until the fixture is
+  swapped for a bigger one.**
+- `cargo stylus check` or `deploy` errors with `execution reverted` while
+  the fixture is confirmed >24KB → **(c) RAN and failed** — this is
+  exactly the regression PR #80 fixed, resurfacing.
+- Check and deploy both succeed on a confirmed >24KB fixture → **(a)**.
+
+## Step 6 — Start the frontend
+
+Launch the `next` binary directly rather than through `yarn`/`yarn start`
+(which is `yarn workspace @ss/nextjs dev` -> `next dev`, per the root and
+`packages/nextjs` `package.json` scripts) — going through `yarn` would put
+an extra wrapper PID between us and the real dev-server process. `next
+dev` itself listens for SIGINT/SIGTERM, forwards it to the child process
+it forks internally, and SIGKILLs that child on its own exit — so a
+single captured PID is sufficient to tear down cleanly.
+
+Launched via `launch-detached.mjs`, same as Step 2's devnode, so it
+survives this shell/session exiting; its PID is recorded in the state
+file, not just a shell variable:
+
+```bash
+NEXTJS_LOG=$(mktemp -t smoke-test-nextjs.XXXXXX.log)
+NEXTJS_PID=$(PORT="$FRONTEND_PORT" node .claude/skills/smoke-test/launch-detached.mjs \
+  "$NEXTJS_LOG" packages/nextjs/node_modules/.bin/next dev packages/nextjs)
+node .claude/skills/smoke-test/state.mjs set nextjsPid "$NEXTJS_PID"
+node .claude/skills/smoke-test/state.mjs set frontendPort "$FRONTEND_PORT"
+```
+
+Runs `next dev` on `$FRONTEND_PORT` (chosen in Step 0 — Next.js honours
+the `PORT` env var when no explicit `--port` is passed).
+
+Assertion — poll up to 90s (first compile can be slow). Uses `$SECONDS`
+instead of GNU coreutils `timeout`, which is not present on stock macOS:
+
+```bash
+deadline=$((SECONDS + 90))
+until [ "$(curl -s -o /dev/null -w '%{http_code}' http://localhost:${FRONTEND_PORT})" = '200' ]; do
+  if [ "$SECONDS" -ge "$deadline" ]; then
+    echo "timed out waiting for frontend to respond 200" >&2
+    exit 1
+  fi
+  sleep 2
+done
+```
+
+- `$FRONTEND_PORT` already bound (shouldn't happen — Step 0 just probed
+  it free, but something else could have grabbed it in the interim), or
+  the process exits immediately → **(b) DID NOT RUN** if caused by
+  environment; **(c)** if `next dev` starts then crashes with a
+  build/type error.
+- Responds 200 within 90s → **(a)**.
+
+## Step 7 — Browser E2E (the whole chain, proven live)
+
+Driven by pure Chrome DevTools Protocol via
+`.claude/skills/smoke-test/browser-e2e.mjs` — **zero new dependencies**
+(Node 24's native `WebSocket`/`fetch` are the whole transport). This
+replaced driving the browser through the `claude-in-chrome` MCP
+extension, which needs a human-attached browser, cannot run in CI, and
+stopped working outright (three consecutive "not connected" failures).
+Do not reintroduce the extension for this step, and do not add
+puppeteer/playwright/chrome-remote-interface/ws or any other package —
+if it can't be done with the Node standard library, stop and report that.
+
+```bash
+FRONTEND_PORT="$FRONTEND_PORT" node .claude/skills/smoke-test/browser-e2e.mjs
+```
+
+The script launches an isolated, detached Chrome (fresh `--user-data-dir`
+temp profile, probed-free `--remote-debugging-port`, headless by default
+— set `SMOKE_TEST_HEADFUL=1` for a visible window while debugging
+locally), drives it entirely through `Runtime.evaluate` (never synthetic
+mouse coordinates — coordinates are the fragile, flaky part of browser
+automation), and polls bounded conditions instead of sleeping a fixed
+duration wherever there isn't a CDP event to wait on instead. It asserts,
+in order:
+
+1. Navigate to `http://localhost:$FRONTEND_PORT/debug`.
+2. **`your-contract`'s `setGreeting` write form actually renders** (via
+   `[data-testid="write-function-form-setGreeting"]`) — not just that the
+   page returned 200. A page that merely renders is not a pass.
+3. `greeting()` reads back the constructor default. Note: `displayTxResult()`
+   (`packages/nextjs/app/debug/_components/contract/utilsDisplay.tsx`)
+   `JSON.stringify()`s plain string results, so the rendered text is
+   `"Building Unstoppable Apps!!!"` **including the literal quote
+   characters** — match that exact form, not the bare string.
+4. The burner wallet is connected. It is IN-PAGE, not an extension — no
+   native dialog, so headless works identically to headful here. **Do not
+   assume a manual "Connect" click is required**: for the `arbitrumNitro`
+   network with `onlyLocalBurnerWallet` (`scaffold.config.ts`),
+   `ScaffoldEthAppWithProviders.tsx` calls `initBurnerPK()` unconditionally
+   on mount and wagmi auto-reconnects the burner connector, so the wallet
+   is very often already connected by the time the write form renders.
+   Check for that first; only drive the `[data-testid="connect-wallet"]`
+   → `[data-testid="burner-account-option"]` flow if a Connect button is
+   actually present. Selecting an account calls `window.location.reload()`
+   — wait on the CDP `Page.loadEventFired` event for that reload, not a
+   poll (polling `document.readyState` right after a client-side reload
+   can race and read the OLD document's already-"complete" state).
+5. Submit `setGreeting("smoke-test-<distinct-value>")` via
+   `[data-testid="write-function-submit"]`, after setting
+   `[data-testid="function-input"]`'s value through React's **native
+   input value setter** (`Object.getOwnPropertyDescriptor(HTMLInputElement.prototype,
+   "value").set`) plus a manually dispatched `input` event — plain
+   `input.value = x` does not work on a React-controlled input; React's
+   own setter shadows the native one, the component's state never
+   updates, and the form silently submits empty.
+6. Poll `[data-testid="display-variable-greeting"] [data-testid="display-variable-value"]`
+   until it equals the new value. This single poll proves both that the
+   tx confirmed and that the read-back matches what was written — the
+   real assertion is this on-chain value changing, not a prose toast
+   string.
+7. Screenshot via `Page.captureScreenshot`, saved under
+   `$TMPDIR/smoke-test-artifacts/`.
+8. Navigate to `/blockexplorer` and page through blocks **while the
+   devnode is mining continuously** (the script runs a background
+   `cast send` loop for the duration of this check) — confirming rows via
+   `[data-testid="blockexplorer-*"]` do not shift, duplicate, or blank out
+   across the page-forward click. This is the regression check
+   `useFetchBlocks.ts`/`app/blockexplorer/**` exist for (hand-ported from
+   upstream in `351a34a`, never previously run against a live devnode).
+9. Navigate to `/` (the homepage) and wait for it to render. No new hard
+   assertion beyond that — this step exists purely for console/overlay
+   coverage. The burner wallet is already connected by this point, so the
+   homepage's `<Address address={connectedAddress} />` renders for real,
+   unlike `/debug` and `/blockexplorer` which never show it; this is the
+   page where a connected address's ENS name/avatar lookups actually fire.
+
+Every interactive element the script drives has an additive
+`data-testid` (see "data-testid surface" below) — the script does not
+match on visible text or CSS classes to find anything, only to read a
+value out of an element it already found by testid.
+
+- Chrome/Chromium binary not found, no free debugging port, or the CDP
+  endpoint/debug page never comes up within its bounded timeout → script
+  exits 1 → **(b) DID NOT RUN — browser automation unavailable**.
+- Wallet won't connect, write tx never confirms/reverts, the read-back
+  value doesn't match, or the block explorer shows a duplicate/blank row
+  under live mining → script exits 2 → **(c) RAN and failed**, with the
+  mismatch (and the screenshot) attached.
+- All assertions hold and both screenshots are captured → script exits 0
+  → **(a)**.
+
+On exit 0 the script kills its own Chrome and removes its temp profile
+dir. On exit 1/2 it leaves Chrome running (same "preserve failure state"
+policy as Step 8) and records its PID/debug port/profile dir in the state
+file so `teardown.sh`'s escape hatch can find and clean it up later.
+
+### Dev-overlay / console advisory (ADVISORY ONLY — never changes the verdict)
+
+No assertion above looks at the Next.js dev overlay or the browser
+console, so a run can pass every assertion while the dev overlay is
+quietly reporting a problem — this was discovered when a smoke-test run
+that passed cleanly still showed a red error badge in both of Step 7's
+screenshots. This sub-check closes that gap, but deliberately does **not**
+gate the run: some of what it finds comes from third-party packages or
+services this repo doesn't control, and a gate nobody can satisfy is a
+gate people learn to bypass. It reports prominently instead — never
+silently — and has its own tri-state that is independent of Step 7's
+main PASS/FAIL:
+
+- Right after the CDP session attaches (before Step 7's first
+  navigation), the script enables the `Log` and `Runtime` CDP domains and
+  registers persistent listeners on `Log.entryAdded`,
+  `Runtime.consoleAPICalled`, and `Runtime.exceptionThrown` — capturing
+  every console/runtime error or warning for the whole session, not just
+  a snapshot at the end.
+- After the block-explorer pagination check, it also does a best-effort
+  DOM read of the dev overlay itself (`document.querySelector('nextjs-portal')`'s
+  shadow root), reporting whether it's present and which heading it shows
+  (`Console Error` / `Build Error` / `Unhandled Runtime Error`). This is
+  corroborating context only — the overlay's internal markup is
+  undocumented and changes across Next.js versions, so matching below
+  relies on the console/runtime capture (stable browser APIs), not on
+  parsing this structure.
+- Each collected issue is reduced to a short, stable **signature** (first
+  line only, hex addresses normalized away) and checked against a
+  **known-issues baseline** — `KNOWN_OVERLAY_ISSUES` near the top of
+  `browser-e2e.mjs`. Each baseline entry has a distinguishing substring to
+  match on, the date it was accepted, and a one-line reason. Matching on
+  a short substring (not a full stack trace) is deliberate: line numbers
+  and hex values churn on every dependency bump and would make a
+  perfectly-fine, already-diagnosed issue look "new" forever.
+  - Signature matches a baseline entry → printed as `KNOWN`, one line, no
+    alarm.
+  - Signature matches nothing in the baseline → printed as **`NEW — not
+    previously accepted`**, prominently, with an explicit note that a
+    human must triage it: either fix it, or add it to
+    `KNOWN_OVERLAY_ISSUES` with a dated reason once someone has actually
+    looked at it.
+  - A baseline entry that matched nothing this run is printed as
+    **`STALE baseline entry`** — it may mean the issue was fixed upstream
+    and the entry should be removed, or (for a timing-dependent signature)
+    that it simply didn't fire within this run's window; the baseline
+    entry's own reason line says which applies.
+- Tri-state for this sub-check itself: if the CDP session never attached
+  (Step 7 failed before console capture could even be wired up), it
+  prints **DID NOT RUN** rather than a false "no issues found" — a check
+  that silently didn't run is exactly the failure mode this whole skill
+  exists to prevent. If capture was live, it always prints a report
+  (even "no console errors/warnings observed"), whether Step 7's own
+  verdict came back PASS, FAIL, or the run crashed partway through —
+  "prominent, never silent" means every exit path prints it.
+
+Signature rule (see the comment above `KNOWN_OVERLAY_ISSUES` in
+`browser-e2e.mjs`): match on something that identifies the CODEPATH — a
+calling hook/component name, or an application-level error-message prefix
+— never on a bare third-party hostname alone. A shared host (a public RPC,
+a demo API key) can be hit by more than one unrelated feature; a bare-host
+match silently absorbs every future codepath that happens to hit the same
+host under one old "accepted" reason. This baseline used to carry a
+public-RPC-CORS entry attributed to the (now-removed) native-currency
+price fetch, matched on the bare `eth.merkle.io` / shared-Alchemy-key
+hostnames — an unrelated ENS lookup (`Address.tsx`) hit the same hosts and
+matched right through it unnoticed, until the price feature that
+"explained" the entry was deleted and the entry had to be re-diagnosed
+from scratch. Don't repeat that: name the codepath in the `match` string.
+
+Seeded baseline (as of 2026-07-21, all confirmed to reproduce identically
+on `origin/main` — i.e. pre-existing, not caused by any change that
+introduced this check):
+
+- **next-themes script-tag warning** — `next-themes@0.4.6`'s
+  `ThemeProvider` renders an internal `<script>` tag to set the theme
+  attribute before hydration (its no-flash-of-wrong-theme technique).
+  React's dev-mode console warns about encountering a `<script>` element
+  mid-render, but the script still runs correctly pre-hydration — this is
+  a third-party, dev-only warning with no production impact, and it is
+  the dev overlay's error badge (its only entry, confirmed by reading the
+  overlay's own DOM content against a live run).
+- **Lit dev-mode notice** — `@reown/appkit-ui` /
+  `@reown/appkit-scaffold-ui` (WalletConnect's wallet-modal UI, pulled in
+  transitively via RainbowKit) build on the `lit` web-components library,
+  which logs a "Lit is in dev mode" notice whenever it isn't built for
+  production — third-party, dev-only, no production impact.
+  Does not appear in the dev-overlay badge, console warning only.
+
+ENS name/avatar lookups (`Address.tsx`, `useEnsName`/`useEnsAvatar`) and
+RainbowKit's own internal ENS resolution for the connected account no
+longer appear here: both are now gated off when the target network is the
+local devnode (see `isLocalNetwork` in `Address.tsx` and
+`isLocalOnlyConfig` in `wagmiConfig.tsx`), so they don't fire — and don't
+need a baseline entry — while this skill runs.
+
+### data-testid surface
+
+These are additive-only tags on the exact elements this script drives —
+no logic/render changes. They are rsynced into the `create-stylus` npm
+template, so treat them as a small public surface: kebab-case, name the
+element (not what the test does with it), no emoji, no copy fragments.
+
+| testid | file:line |
+| --- | --- |
+| `connect-wallet` | `packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/index.tsx` |
+| `burner-account-option` | `packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/BurnerWalletModal.tsx` |
+| `write-function-form-<fnName>` | `packages/nextjs/app/debug/_components/contract/WriteOnlyFunctionForm.tsx` |
+| `write-function-submit` | `packages/nextjs/app/debug/_components/contract/WriteOnlyFunctionForm.tsx` |
+| `function-input` | `packages/nextjs/components/scaffold-eth/Input/InputBase.tsx` |
+| `display-variable-<fnName>` | `packages/nextjs/app/debug/_components/contract/DisplayVariable.tsx` |
+| `display-variable-value` | `packages/nextjs/app/debug/_components/contract/DisplayVariable.tsx` |
+| `blockexplorer-table` | `packages/nextjs/app/blockexplorer/_components/TransactionsTable.tsx` |
+| `blockexplorer-row` | `packages/nextjs/app/blockexplorer/_components/TransactionsTable.tsx` |
+| `blockexplorer-block-number` | `packages/nextjs/app/blockexplorer/_components/TransactionsTable.tsx` |
+| `blockexplorer-prev-page` / `blockexplorer-next-page` / `blockexplorer-page-label` | `packages/nextjs/app/blockexplorer/_components/PaginationButton.tsx` |
+
+Nothing was left untagged/fragile — every element the script interacts
+with has a testid. If a future revision of this script needs to target a
+new element, tag it the same way rather than falling back to text/class
+matching.
+
+## Step 8 — Teardown (conditional on verdict)
+
+Whether this step tears anything down now depends on the outcome of
+Steps 1–7:
+
+- **Verdict is PASS** → tear down fully, exactly as before.
+- **Verdict is FAIL, INCONCLUSIVE, or the run crashed partway through
+  before reaching a verdict** → do **NOT** tear down. A live failure
+  state is the only thing you can actually debug — tearing it down
+  forces a full re-run of devnode + deploy + frontend just to get back
+  to the moment of failure. Leave the devnode container and the dev
+  server running and leave the artifacts in place; print the escape
+  hatch instead (below).
+
+The actual teardown logic lives in a standalone, idempotent script —
+`.claude/skills/smoke-test/teardown.sh` — precisely so that "the exact
+teardown command" quoted in the escape hatch is a real, single,
+copy-pasteable command and not a list of steps to retype. It is safe to
+run twice and safe to run when nothing is alive: killing an already-dead
+PID and removing an already-absent container both no-op quietly, and
+nothing in the script is allowed to start erroring on a repeat run.
+
+**`teardown.sh` reads PIDs from the state file
+(`.claude/skills/smoke-test/.smoke-state.json`) by default** — it needs
+no arguments at all. This matters now that Steps 2/6/7 launch their
+processes detached (survives the session that started them — see
+"Detached processes and the state file" below): a PID sitting only in
+`$NEXTJS_PID`/`$CHAIN_PID` in this shell is not enough anymore, since a
+human debugging a FAIL will very likely be in a *different* shell/session
+by the time they run teardown. `NEXTJS_PID=<pid> CHAIN_PID=<pid>` env
+vars still override the state file, for the rare case you want to target
+something else.
+
+### On PASS
+
+```bash
+.claude/skills/smoke-test/teardown.sh
+```
+
+- If the script's own step-7 verification prints any `LEAKED:` line or
+  non-empty `git status`, teardown itself **failed** — report this
+  explicitly (it is not covered by the PASS/INCONCLUSIVE/FAIL verdict,
+  but it must be surfaced, since it will cause the *next* run's Step 0
+  preflight to fail with a misleading "port busy" or "dirty tree"
+  message).
+- `deployedContracts.ts` is the one tracked file this skill is allowed to
+  touch mid-run (Step 4) — the script's `git checkout --` on it is what
+  keeps the READ-ONLY contract's spirit intact on a PASS: the working
+  tree must be bit-for-bit unchanged by the time this skill exits.
+- Step 7's `browser-e2e.mjs` already killed its own Chrome and cleared its
+  state-file keys on its own exit 0, so there's normally nothing Chrome-
+  related left for this script to do on a PASS.
+
+### On FAIL / INCONCLUSIVE / crash
+
+Do not call `teardown.sh`. Instead print an escape hatch with this run's
+actual literal values substituted in (not `$VAR` references — the reader
+will use these in a fresh shell where the variables aren't set; get them
+with `node .claude/skills/smoke-test/state.mjs dump` if they've scrolled
+out of view):
+
+```
+=== Smoke test did not pass — live state left running for debugging ===
+Frontend:      http://localhost:<FRONTEND_PORT>/debug
+NEXTJS_PID:    <NEXTJS_PID>
+CHAIN_PID:     <CHAIN_PID>
+Container:     nitro-dev
+CHROME_PID:    <chromePid, if Step 7 got far enough to launch one>
+Chrome debug:  http://127.0.0.1:<chromeDebugPort>/json
+
+All of the above genuinely survive this session ending — they were
+launched detached (launch-detached.mjs / browser-e2e.mjs's spawn with
+detached:true), specifically so this escape hatch isn't printing PIDs
+that are already dead by the time you read them.
+
+The working tree is left DIRTY on purpose: packages/nextjs/contracts/
+deployedContracts.ts stays modified and packages/stylus/deployments
+stays present — they are evidence of this run's deploy. The next
+preflight run will hit exit 4 (dirty tree) until this is cleaned up;
+that is the intended loud signal that a prior run failed and was never
+torn down, not a mysterious bug. Do not treat exit 4 as "something is
+broken" without first checking whether it's this.
+
+When done debugging, tear everything down with (no arguments needed --
+it reads .smoke-state.json):
+  .claude/skills/smoke-test/teardown.sh
+```
+
+### Detached processes and the state file
+
+Before this fix, Steps 2/6 launched the devnode and frontend as plain
+`cmd &` background jobs. That PID lived only in a shell variable, and the
+process itself stayed in the same process group as the shell that
+started it. Both of those broke the FAIL-path escape hatch above: the
+invoking shell or session ending sends its terminating signal to that whole
+process group, killing the "preserved" devnode and frontend along with it, so
+the escape hatch printed PIDs that were already dead by the time a human
+read them — teardown-on-FAIL was theatre, not a real safety net.
+
+The fix has two parts, used by Steps 2, 6, and (on FAIL) 7:
+
+- **`launch-detached.mjs`** launches a command via Node's
+  `spawn({detached: true})`, which calls `setsid(2)` directly through
+  libuv on POSIX — making the child a new session/process-group leader,
+  immune to signals sent to the launching shell's group. (Deliberately
+  *not* implemented by shelling out to the `setsid` CLI binary: that's
+  util-linux and isn't present on macOS by default, unlike the libuv
+  syscall path, which works identically on macOS and Linux.)
+- **`state.mjs`** is the durable record of what's alive —
+  `.claude/skills/smoke-test/.smoke-state.json` (gitignored), keyed by
+  `chainPid`, `nextjsPid`, `frontendPort`, and (only when Step 7 leaves
+  Chrome running on a non-PASS exit) `chromePid`/`chromeDebugPort`/
+  `chromeUserDataDir`. `teardown.sh` reads it instead of relying on shell
+  variables that don't outlive the session; `preflight.sh` also checks
+  for a leftover state file as a leaked-prior-run signal, the same class
+  of check as the dirty-tree check next to it.
+
+## Step 9 — Sepolia deploy (opt-in, live network)
+
+Steps 1–8 only prove the LOCAL devnode path. They never touch a real
+network, so on their own they cannot prove a user could actually deploy
+this scaffold to mainnet. Step 9 closes that gap with a real deploy to
+Arbitrum Sepolia, then reads the deployed contract's state back over the
+live RPC.
+
+**Scope is deploy + read back on-chain only.** No frontend/wallet/UI work:
+`scaffold.config.ts` sets `onlyLocalBurnerWallet: true`, so the burner
+wallet is hidden on non-local networks and driving MetaMask through pure
+CDP is out of scope. Do not change `onlyLocalBurnerWallet` to make this
+step easier to browser-test.
+
+Step 9 is fully independent of Steps 1–8: it needs no local devnode, no
+Docker container, no frontend dev server, and binds no local port. It can
+be run on its own without the rest of this skill, and running it does not
+require Steps 1–8 to have passed (or even to have run).
+
+### Step 9a — Tool gate (cast)
+
+Steps 1–8 already require `cast` (Foundry) — checked once, up front, by
+Step 0's `preflight.sh` (`check_cmd cast "install Foundry..."`), before
+Step 2 ever starts the devnode. Step 9 is designed to run standalone
+without Steps 1–8 having run at all (see above), so it cannot rely on
+that check having already happened — it re-checks for itself, with its
+own distinct SKIP reason, rather than letting a missing `cast` surface
+as a confusing failure three sub-steps later:
+
+```bash
+command -v cast >/dev/null 2>&1
+```
+
+- Missing → **SKIPPED — cast (Foundry) not installed.** Point at the same
+  install hint `preflight.sh` uses: `curl -L https://foundry.paradigm.xyz
+  | bash && foundryup`. This is not a failure and does not affect the
+  Steps 1–7 verdict.
+- Present → proceed to Step 9b.
+
+### Step 9b — Credentials gate (opt-in signal)
+
+`yarn deploy --network sepolia` reads `ACCOUNT_ADDRESS_SEPOLIA`,
+`RPC_URL_SEPOLIA`, and `PRIVATE_KEY_SEPOLIA` from `packages/stylus/.env`
+itself (via `dotenvConfig` in `packages/stylus/scripts/utils/network.ts`).
+Populating those three in `.env` is itself the opt-in: no separate
+confirm flag is needed on top of them, matching the "SKIP by default"
+contract — a fresh clone's `.env.example` ships the whole `## sepolia`
+block blank, so this step SKIPs out of the box until an operator
+deliberately fills it in.
+
+This gate — and every later sub-step that needs these values in the
+current shell (9c's balance check, 9d's deploy) — uses **one single
+mechanism**: source `packages/stylus/.env` into the shell once, then
+check the resulting environment. There is no separate file-grep check;
+what ends up in the shell environment after this `source` is the only
+thing that decides SKIP vs proceed, for this step and every step after it:
+
+```bash
+[ -f packages/stylus/.env ] && source packages/stylus/.env
+MISSING_KEYS=""
+[ -z "${ACCOUNT_ADDRESS_SEPOLIA:-}" ] && MISSING_KEYS="$MISSING_KEYS ACCOUNT_ADDRESS_SEPOLIA"
+[ -z "${RPC_URL_SEPOLIA:-}" ] && MISSING_KEYS="$MISSING_KEYS RPC_URL_SEPOLIA"
+[ -z "${PRIVATE_KEY_SEPOLIA:-}" ] && MISSING_KEYS="$MISSING_KEYS PRIVATE_KEY_SEPOLIA"
+```
+
+Never print, echo, `cat`, log, or commit the private key. If you need to
+show a variable is set, print its length, not its value. Never read the
+rest of `.env` back to the terminal — that file may hold real mainnet
+secrets in other blocks.
+
+- Any of the three unset/blank in the shell after sourcing →
+  **SKIPPED — Sepolia credentials not set.** Print which key(s) are
+  missing and point at the `## sepolia` block in
+  `packages/stylus/.env.example`. This is not a failure and does not
+  affect the Steps 1–7 verdict.
+- All three present → proceed to Step 9c.
+
+### Step 9c — Balance gate
+
+Insufficient gas SKIPs, it does not hard-fail — funding is an operator
+action, not a code regression. Reuses `$RPC_URL_SEPOLIA` /
+`$ACCOUNT_ADDRESS_SEPOLIA` already in the shell from Step 9b's `source` —
+no second read of `.env`:
+
+```bash
+BALANCE_WEI=$(cast balance --rpc-url "$RPC_URL_SEPOLIA" "$ACCOUNT_ADDRESS_SEPOLIA")
+```
+
+- `BALANCE_WEI` is `0` → **SKIPPED — deployer has zero Sepolia ETH.**
+  Report the address and point at the faucets already listed in this
+  repo's `readme.md` ("Arbitrum Testnet Faucets"):
+  [Chainlink Faucet](https://faucets.chain.link/arbitrum-sepolia),
+  [QuickNode Faucet](https://faucet.quicknode.com/arbitrum/sepolia),
+  [Alchemy Faucet](https://sepoliafaucet.com/). Do not hard-fail the run.
+- `cast` errors for a reason other than the tool being absent (already
+  ruled out by Step 9a) — e.g. `$RPC_URL_SEPOLIA` unreachable → **SKIPPED
+  — Sepolia RPC unreachable** (external/environmental, not a code
+  regression).
+- `BALANCE_WEI` is nonzero → proceed to Step 9d. A nonzero-but-tiny balance
+  is not pre-screened further here — if it turns out too low to cover gas,
+  `cargo stylus deploy` itself will fail with an out-of-funds error from
+  the RPC; treat that specific failure mode the same as a zero balance
+  (SKIPPED, with the same faucet pointer), since it is still an operator
+  funding gap, not a code defect. Any other deploy failure (e.g. the
+  contract itself reverting, a compile error) is a real **FAIL**.
+
+### Step 9d — Deploy
+
+```bash
+yarn deploy --network sepolia
+```
+
+This resolves `sepolia` to `arbitrumSepolia` (`packages/stylus/scripts/
+utils/network.ts`'s `ALIASES` map) and runs the same `cargo stylus deploy`
+→ `export-abi` → `deployedContracts.ts` chain Step 4 runs locally, just
+against `RPC_URL_SEPOLIA` instead of the devnode. `yarn deploy` is a fresh
+process that reads `packages/stylus/.env` itself — it does not depend on
+Step 9b/9c's shell-local `source`, which exists only for this skill's own
+precondition checks. It also writes to
+`packages/stylus/deployments/421614_latest.json` (Sepolia's chain ID) —
+gitignored, safe to accumulate across re-runs, same as any other network's
+deployment history.
+
+Assertion:
+
+```bash
+cast receipt <deployment-tx-hash> --rpc-url "$RPC_URL_SEPOLIA"
+```
+
+must show `status  1 (success)`.
+
+- `yarn` itself missing, or the tool/credentials/balance gates above
+  already caught the problem → already **SKIPPED**, this step is not
+  reached.
+- `cargo stylus deploy` exits non-zero for an out-of-funds reason → treat
+  as **SKIPPED** (see Step 9c). Any other non-zero exit, or exit 0 with a
+  receipt `status` of `0` (reverted) → **FAIL**.
+- Exit 0 and receipt `status  1` → **(a)**, proceed to Step 9e.
+
+### Step 9e — Read back on-chain state
+
+Prove the deploy actually landed by reading real contract state back over
+the Sepolia RPC — not just trusting the CLI's own success message:
+
+```bash
+cast call <deployed-address> "greeting()(string)" --rpc-url "$RPC_URL_SEPOLIA"
+cast call <deployed-address> "owner()(address)" --rpc-url "$RPC_URL_SEPOLIA"
+cast code <deployed-address> --rpc-url "$RPC_URL_SEPOLIA"
+```
+
+Assertion: `greeting()` returns the constructor default
+(`"Building Unstoppable Apps!!!"`), `owner()` returns
+`$ACCOUNT_ADDRESS_SEPOLIA`, and `cast code` returns non-empty bytecode.
+
+- Any of the three don't hold → **FAIL** — the deploy transaction
+  succeeded but the deployed contract doesn't behave as expected.
+- All three hold → **(a)**.
+
+### Step 9f — Cleanup (always, regardless of outcome)
+
+`yarn deploy` writes the Sepolia entry into the tracked
+`packages/nextjs/contracts/deployedContracts.ts` the moment it runs,
+before Step 9e's assertions even execute — same file Step 4/Step 8 touch
+for the local devnode. Restore it so this skill's READ-ONLY contract holds
+for Sepolia too, regardless of whether Step 9d/9e passed or failed:
+
+```bash
+git checkout -- packages/nextjs/contracts/deployedContracts.ts
+```
+
+Do **not** delete `packages/stylus/deployments/421614_latest.json` or the
+exported ABI next to it — both are gitignored, and both are the real
+record of this (non-throwaway) Sepolia deployment, not scratch artifacts
+to clean up. This step is safe to re-run: each run deploys a fresh
+contract at a new address using the same funded wallet; there is no port,
+container, or state-file to collide with a prior run of this step or with
+Steps 1–8.
+
+### Reporting Step 9
+
+Report exactly one of:
+
+- **SKIPPED** — with the specific reason (`cast` not installed,
+  credentials absent, zero/insufficient balance, RPC unreachable).
+- **PASS** — with the deployed contract address, the deploy tx hash and
+  its `https://sepolia.arbiscan.io/tx/<hash>` link, and the raw read-back
+  output from Step 9e.
+- **FAIL** — with the exact command and exact error output.
+
+A SKIPPED Step 9 must appear explicitly as SKIPPED in the run's final
+report — never silently omitted, and never folded into an overall PASS.
+
+## Common Mistakes
+
+- Treating a missing tool, closed env gate, or busy port as anything
+  other than **(b)**. These are silent-pass traps — they must surface as
+  INCONCLUSIVE, never PASS.
+- Skipping Step 3 because Step 2's script "already handles ArbOS 60" —
+  Step 2 *attempts* the upgrade; Step 3 is the independent verification
+  that it actually landed on this run's container.
+- Skipping Step 5 because Step 4's small contract deployed fine —
+  `your-contract` is under the 24KB single-fragment threshold and cannot
+  exercise the multi-fragment code path at all.
+- Calling Step 7 a pass because `/debug` returned 200. Rendering proves
+  nothing about the deploy/ABI/signing chain; only the read-back
+  assertion (Step 7, sub-step 6) does.
+- Editing `nitro-devnode/*.sh`, contract source, or frontend hooks to
+  make a failing step pass. This skill is READ-ONLY — report the failure
+  instead. (`data-testid` attributes added to drive Step 7 are the one
+  approved exception — additive only, never a logic/render change.)
+- Tearing down on FAIL/INCONCLUSIVE. Full teardown now runs only on
+  PASS — on any other outcome, leave the live state running and print
+  the escape hatch instead; see Step 8.
+- Printing the escape hatch with literal `$NEXTJS_PID`/`$CHAIN_PID`/
+  `$FRONTEND_PORT`/`$CHROME_PID` text instead of the run's actual values.
+  The reader won't have those variables set in a fresh shell.
+- Setting a React-controlled `<input>`'s value with plain
+  `input.value = x` in Step 7. React shadows the native setter, so the
+  component's own state never updates and the form submits empty — use
+  the native setter via `Object.getOwnPropertyDescriptor` plus a
+  dispatched `input` event (see Step 7, sub-step 5).
+- Assuming Step 7 must click a "Connect" button. For the local devnode
+  network the burner wallet auto-connects on page load; the script must
+  check for the already-connected state first (see Step 7, sub-step 4).
+- Reintroducing the `claude-in-chrome` MCP extension for Step 7, or
+  adding puppeteer/playwright/chrome-remote-interface/ws to make browser
+  automation easier. Pure CDP with zero new dependencies is the point —
+  every dependency here is inherited by every fork and by
+  `create-stylus`.
+- Treating Step 9 SKIPPED as a reason to omit it from the report, or as a
+  FAIL. SKIPPED is a legitimate, expected outcome when Sepolia credentials
+  aren't configured — report it explicitly, don't fail the run and don't
+  fold it into Steps 1–7's verdict.
+- Leaving `packages/nextjs/contracts/deployedContracts.ts` modified after
+  Step 9. It gets written by `yarn deploy --network sepolia` itself,
+  before Step 9's own assertions run — restore it in Step 9f regardless
+  of whether Step 9 passed or failed.
+- Editing `packages/stylus/.env` to test Step 9's SKIP path. Instead,
+  `source packages/stylus/.env` as Step 9b does, then `unset
+  ACCOUNT_ADDRESS_SEPOLIA RPC_URL_SEPOLIA PRIVATE_KEY_SEPOLIA` — unsetting
+  *before* sourcing proves nothing, since the `source` would just
+  repopulate them from the file a line later. Unsetting *after* sourcing
+  reproduces the exact shell state a blank `## sepolia` block in `.env`
+  would leave behind, without ever touching the file (which may hold
+  real credentials).
+- Assuming Step 9b's gate reads `.env` by grepping the file (the way Step
+  1b's devnet gate does). It doesn't: Step 9b sources the file into the
+  shell and checks the resulting environment variables directly — one
+  mechanism, reused as-is by 9c and 9d. Don't reintroduce a second,
+  file-based check that could disagree with it.

--- a/.claude/skills/smoke-test/browser-e2e.mjs
+++ b/.claude/skills/smoke-test/browser-e2e.mjs
@@ -1,0 +1,844 @@
+#!/usr/bin/env node
+// .claude/skills/smoke-test/browser-e2e.mjs
+//
+// Step 7 (Browser E2E) of the smoke-test skill, driven by pure Chrome
+// DevTools Protocol -- zero new dependencies. Node 24 ships a native
+// `WebSocket` and `fetch`, which is the whole CDP transport; no puppeteer,
+// playwright, chrome-remote-interface, or ws. This repo is a template
+// inherited by every fork and by `create-stylus`, so that constraint is not
+// negotiable.
+//
+// Replaces driving the browser through the claude.ai/chrome MCP extension,
+// which needs a human-attached browser, cannot run in CI, and is not
+// reproducible.
+//
+// Usage:
+//   FRONTEND_PORT=<port> node .claude/skills/smoke-test/browser-e2e.mjs
+//
+// Env vars:
+//   FRONTEND_PORT     required -- port Step 6's `next dev` is listening on
+//   CHROME_PATH       optional -- override Chrome binary discovery
+//   SMOKE_TEST_HEADFUL=1  optional -- run Chrome with a visible window
+//                     (default is headless, since reproducibility in CI is
+//                     the whole point of this rewrite)
+//
+// Exit codes (mirrors the skill's tri-state reporting):
+//   0 -- RAN and passed (a)
+//   1 -- DID NOT RUN (b) -- environment/tooling problem: Chrome missing, no
+//        free debugging port, CDP never came up, page never loaded
+//   2 -- RAN and failed (c) -- an assertion did not hold: wallet wouldn't
+//        connect, write tx never confirmed, read-back mismatch, block
+//        explorer pagination showed a duplicate/blank row
+//
+// On a PASS this script kills its own Chrome and removes its temp profile
+// dir. On anything else, it leaves Chrome running (same policy as Step 8)
+// and records its PID/debug port/profile dir in the shared state file
+// (state.mjs) so teardown.sh's escape hatch can find and clean it up later.
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { setState, unsetState } from "./state.mjs";
+
+class EnvironmentError extends Error {}
+class AssertionFailure extends Error {}
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+function log(msg) {
+  console.log(`[browser-e2e] ${msg}`);
+}
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const FRONTEND_PORT = process.env.FRONTEND_PORT;
+if (!FRONTEND_PORT) {
+  console.error("FRONTEND_PORT is required (the port Step 6's next dev is listening on)");
+  process.exit(1);
+}
+const FRONTEND_BASE = `http://localhost:${FRONTEND_PORT}`;
+const RPC_URL = "http://127.0.0.1:8547";
+// Well-known nitro-devnode prefunded dev accounts -- see SKILL.md Step 1b
+// and packages/nextjs/utils/scaffold-stylus/supportedChains.ts. Not secrets.
+const MINER_PRIVATE_KEY = "0xb6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659";
+const MINER_TO_ADDRESS = "0xDD09b55496EaA3cFAe23137ABDeA52a9a979B70e";
+
+const HEADLESS = process.env.SMOKE_TEST_HEADFUL !== "1";
+const ARTIFACT_DIR = path.join(os.tmpdir(), "smoke-test-artifacts");
+fs.mkdirSync(ARTIFACT_DIR, { recursive: true });
+
+// ---------------------------------------------------------------------------
+// Dev-overlay / console advisory -- ADVISORY ONLY, see printDevOverlayAdvisory
+// ---------------------------------------------------------------------------
+//
+// The Next.js dev overlay's error badge and the browser console are not
+// checked by any assertion above -- a run can pass every assertion while the
+// app is quietly reporting a problem via the overlay. This section collects
+// console/runtime events and the overlay's own DOM state for the whole
+// session and reports them prominently, but a match here NEVER changes the
+// PASS/FAIL/INCONCLUSIVE verdict: some of these come from third-party code
+// or third-party services this repo doesn't control, and a gate nobody can
+// satisfy is a gate people learn to route around.
+//
+// To keep a silent "1 issue" from drifting to 3 unnoticed, every observed
+// issue is matched against this known-issues baseline by a short, stable
+// substring (never a full stack trace -- line numbers churn on every
+// dependency bump). Add an entry here, dated, with a one-line reason, once a
+// human has actually looked at a NEW issue and decided it's acceptable.
+//
+// Signature rule: match on something that identifies the CODEPATH (a calling
+// hook/component name, or an application-level error-message prefix), never
+// on a bare third-party hostname by itself. A shared host like a public RPC
+// or a demo API key can be hit by more than one unrelated feature; a bare-
+// host match silently absorbs every future codepath that happens to hit the
+// same host under one old, unrelated "accepted" reason, and a regression in
+// a brand-new feature would then read as KNOWN instead of NEW. Case in
+// point: an earlier version of this baseline matched bare "eth.merkle.io" /
+// the shared Alchemy demo key host, accepted as a price-fetch fallback --
+// then a completely unrelated ENS lookup (Address.tsx) started hitting the
+// exact same hosts and matched right through it, unnoticed, until the price
+// feature that "explained" the entry was deleted.
+const KNOWN_OVERLAY_ISSUES = [
+  {
+    match: "Encountered a script tag while rendering React component",
+    acceptedDate: "2026-07-21",
+    reason:
+      "Third-party: next-themes@0.4.6's ThemeProvider renders an internal <script> tag " +
+      "to set the theme attribute before hydration (its no-flash-of-wrong-theme trick). " +
+      "React's dev-mode console warns about seeing a <script> element mid-render, but the " +
+      "script still runs correctly pre-hydration -- dev-only, no production impact. This IS " +
+      "the dev-overlay's error badge (its only entry). Confirmed pre-existing on origin/main " +
+      "(identical ThemeProvider.tsx/layout.tsx and next-themes/next versions); not caused by " +
+      "any change on this branch.",
+  },
+  {
+    match: "Lit is in dev mode",
+    acceptedDate: "2026-07-21",
+    reason:
+      "Third-party: @reown/appkit-ui and @reown/appkit-scaffold-ui (WalletConnect's wallet " +
+      "modal UI, pulled in transitively via RainbowKit) build on the `lit` web-components " +
+      "library, which logs this notice whenever it isn't built in production mode -- a dev- " +
+      "only self-check with no production impact. Does not appear in the dev-overlay badge, " +
+      "console warning only.",
+  },
+];
+
+function matchBaseline(signature) {
+  return KNOWN_OVERLAY_ISSUES.find(known => signature.includes(known.match));
+}
+
+// First line only, dependency-version/address noise stripped, so the
+// signature is what a human would recognize as "the same error" even after
+// unrelated line-number or hex-value churn.
+function normalizeSignature(text) {
+  return String(text)
+    .split("\n")[0]
+    .replace(/0x[0-9a-fA-F]+/g, "0x…")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function consoleArgText(arg) {
+  if (arg.value !== undefined) return String(arg.value);
+  if (arg.description) return arg.description.split("\n")[0];
+  if (arg.className) return arg.className;
+  return arg.type || "";
+}
+
+// Mutated for the life of the run, then read by printDevOverlayAdvisory()
+// from both the success and failure exit paths at the bottom of this file --
+// this must report every run, not just a PASS, per the "never silently" rule.
+const devOverlayState = {
+  advisoryRan: false,
+  collectedIssues: new Map(), // signature -> { source, level, signature, count, sample }
+  overlayCheck: null,
+  overlayCheckError: null,
+};
+
+function recordIssue(source, level, rawText) {
+  const signature = normalizeSignature(rawText);
+  if (!signature) return;
+  const key = `${level}:${signature}`;
+  const existing = devOverlayState.collectedIssues.get(key);
+  if (existing) existing.count += 1;
+  else devOverlayState.collectedIssues.set(key, { source, level, signature, count: 1, sample: String(rawText).slice(0, 500) });
+}
+
+// Best-effort read of the Next.js dev overlay's own DOM state. This is
+// corroborating context for the report only -- the overlay's internal shadow-
+// DOM markup is undocumented and Next-version-specific, so signature matching
+// above relies on the console/runtime capture (stable browser APIs), not on
+// parsing this structure.
+async function checkDevOverlay(cdp) {
+  return evaluate(
+    cdp,
+    `(() => {
+      const portal = document.querySelector('nextjs-portal');
+      if (!portal || !portal.shadowRoot) return { present: false };
+      const text = portal.shadowRoot.textContent || "";
+      const headingMatch = text.match(/Console Error|Build Error|Unhandled Runtime Error|Runtime Error/);
+      return { present: true, heading: headingMatch ? headingMatch[0] : null };
+    })()`,
+  );
+}
+
+// Prints the advisory report. Called from BOTH the success and failure exit
+// paths at the bottom of this file so a match is reported "prominently,
+// never silently" regardless of the run's PASS/FAIL/INCONCLUSIVE verdict --
+// and never throws, since a failure in here must not change that verdict.
+function printDevOverlayAdvisory() {
+  console.log("");
+  console.log("=== Dev-overlay / console advisory (ADVISORY ONLY -- does not affect the verdict above) ===");
+  if (!devOverlayState.advisoryRan) {
+    console.log("DID NOT RUN -- console/runtime capture was never enabled (Chrome/CDP session never attached).");
+    return;
+  }
+  const observed = [...devOverlayState.collectedIssues.values()];
+  if (!observed.length) {
+    console.log("No console errors/warnings observed during this run.");
+  }
+  const matchedBaseline = new Set();
+  for (const issue of observed) {
+    const baseline = matchBaseline(issue.signature);
+    if (baseline) {
+      matchedBaseline.add(baseline.match);
+      console.log(`KNOWN  [${issue.source}/${issue.level}] (x${issue.count}) ${issue.signature.slice(0, 160)}`);
+    } else {
+      console.log(`NEW — not previously accepted  [${issue.source}/${issue.level}] (x${issue.count}) ${issue.signature.slice(0, 300)}`);
+      console.log(`  -> a human must triage this: fix it, or add it to KNOWN_OVERLAY_ISSUES in browser-e2e.mjs with a dated reason.`);
+    }
+  }
+  for (const known of KNOWN_OVERLAY_ISSUES) {
+    if (!matchedBaseline.has(known.match)) {
+      console.log(`STALE baseline entry (accepted ${known.acceptedDate}, not observed this run) -- consider removing: "${known.match}"`);
+    }
+  }
+  if (devOverlayState.overlayCheckError) {
+    console.log(`Dev-overlay DOM check: DID NOT RUN -- ${devOverlayState.overlayCheckError.message}`);
+  } else if (devOverlayState.overlayCheck) {
+    const { present, heading } = devOverlayState.overlayCheck;
+    console.log(`Dev-overlay DOM check: nextjs-portal present=${present}${present ? `, heading=${heading ?? "none"}` : ""}`);
+  }
+}
+
+const results = []; // { name, status: "PASS"|"FAIL"|"SKIP", detail }
+function record(name, status, detail = "") {
+  results.push({ name, status, detail });
+  log(`${status === "PASS" ? "[PASS]" : "[FAIL]"} ${name}${detail ? ` -- ${detail}` : ""}`);
+}
+
+// ---------------------------------------------------------------------------
+// Chrome discovery + launch
+// ---------------------------------------------------------------------------
+
+function findChromeBinary() {
+  if (process.env.CHROME_PATH && fs.existsSync(process.env.CHROME_PATH)) {
+    return process.env.CHROME_PATH;
+  }
+  const candidates = [
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/Applications/Chromium.app/Contents/MacOS/Chromium",
+    "/usr/bin/google-chrome",
+    "/usr/bin/google-chrome-stable",
+    "/usr/bin/chromium",
+    "/usr/bin/chromium-browser",
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  throw new EnvironmentError(
+    `No Chrome/Chromium binary found (checked: ${candidates.join(", ")}; override with CHROME_PATH)`,
+  );
+}
+
+async function findFreePort(startPort, attempts = 20) {
+  const net = await import("node:net");
+  for (let offset = 0; offset < attempts; offset++) {
+    const candidate = startPort + offset;
+    const free = await new Promise(resolve => {
+      const server = net.createServer();
+      server.once("error", () => resolve(false));
+      server.listen(candidate, "127.0.0.1", () => {
+        server.close(() => resolve(true));
+      });
+    });
+    if (free) return candidate;
+    log(`debugging port ${candidate} busy, trying next`);
+  }
+  throw new EnvironmentError(`No free debugging port found in range ${startPort}-${startPort + attempts - 1}`);
+}
+
+async function waitForCdpReady(port, timeoutMs = 15000) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/json/version`);
+      if (res.ok) return res.json();
+    } catch (err) {
+      lastError = err;
+    }
+    await sleep(200);
+  }
+  throw new EnvironmentError(
+    `Chrome's CDP endpoint on port ${port} never became reachable within ${timeoutMs}ms (last error: ${lastError?.message})`,
+  );
+}
+
+function launchChrome(port, userDataDir) {
+  const bin = findChromeBinary();
+  const args = [
+    `--remote-debugging-port=${port}`,
+    `--user-data-dir=${userDataDir}`,
+    "--no-first-run",
+    "--no-default-browser-check",
+    // Recent Chrome rejects CDP connections whose Host/Origin isn't
+    // explicitly allowed; without this a same-machine, non-browser
+    // WebSocket client can still get a 403 on the upgrade.
+    "--remote-allow-origins=*",
+    // Headless defaults to a small window (observed 756x469 elsewhere);
+    // at that size a position:fixed element can cover the exact value a
+    // screenshot is meant to prove, even though the CDP assertion itself
+    // (which reads textContent, not pixels) is unaffected either way.
+    "--window-size=1440,900",
+  ];
+  if (HEADLESS) args.push("--headless=new");
+
+  const logFile = fs.openSync(path.join(ARTIFACT_DIR, `chrome-${port}.log`), "a");
+  const child = spawn(bin, args, {
+    detached: true,
+    stdio: ["ignore", logFile, logFile],
+  });
+  child.unref();
+  return child;
+}
+
+// ---------------------------------------------------------------------------
+// Minimal CDP client (JSON-RPC over the native WebSocket)
+// ---------------------------------------------------------------------------
+
+class CDP {
+  constructor(ws) {
+    this.ws = ws;
+    this.nextId = 1;
+    this.pending = new Map();
+    this.eventListeners = new Map(); // method -> Set<fn>
+    ws.addEventListener("message", event => {
+      const msg = JSON.parse(event.data);
+      if (msg.id !== undefined && this.pending.has(msg.id)) {
+        const { resolve, reject } = this.pending.get(msg.id);
+        this.pending.delete(msg.id);
+        if (msg.error) reject(new Error(`CDP error (${msg.error.code}): ${msg.error.message}`));
+        else resolve(msg.result);
+      } else if (msg.method && this.eventListeners.has(msg.method)) {
+        for (const handler of this.eventListeners.get(msg.method)) handler(msg.params);
+      }
+    });
+  }
+
+  send(method, params = {}) {
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.ws.send(JSON.stringify({ id, method, params }));
+    });
+  }
+
+  // One-shot listener for the next occurrence of `method`, resolving with
+  // its params, bounded by timeoutMs so a missed event can't hang forever.
+  once(method, timeoutMs, description = method) {
+    return new Promise((resolve, reject) => {
+      if (!this.eventListeners.has(method)) this.eventListeners.set(method, new Set());
+      const set = this.eventListeners.get(method);
+      const timer = setTimeout(() => {
+        set.delete(handler);
+        reject(new EnvironmentError(`Timed out after ${timeoutMs}ms waiting for CDP event: ${description}`));
+      }, timeoutMs);
+      const handler = params => {
+        clearTimeout(timer);
+        set.delete(handler);
+        resolve(params);
+      };
+      set.add(handler);
+    });
+  }
+
+  // Persistent listener for every occurrence of `method` for the life of the
+  // session -- used by the dev-overlay/console advisory collector below,
+  // which needs to see every console message from CDP session attach through
+  // the end of the run, not just one occurrence.
+  on(method, handler) {
+    if (!this.eventListeners.has(method)) this.eventListeners.set(method, new Set());
+    this.eventListeners.get(method).add(handler);
+  }
+}
+
+async function evaluate(cdp, expression) {
+  const result = await cdp.send("Runtime.evaluate", {
+    expression,
+    returnByValue: true,
+    awaitPromise: true,
+  });
+  if (result.exceptionDetails) {
+    const desc = result.exceptionDetails.exception?.description || JSON.stringify(result.exceptionDetails);
+    throw new Error(`Runtime.evaluate threw: ${desc}`);
+  }
+  return result.result?.value;
+}
+
+// Poll a condition expression (must evaluate to a truthy JS value) with a
+// bounded timeout. Used for anything that ISN'T a full-page navigation --
+// app hydration, a contract read landing, a tx confirming, a table
+// re-rendering -- where there's no single CDP event to wait on instead.
+async function waitFor(cdp, expression, { timeoutMs = 30000, intervalMs = 400, description = expression } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  let last;
+  while (Date.now() < deadline) {
+    last = await evaluate(cdp, expression);
+    if (last) return last;
+    await sleep(intervalMs);
+  }
+  throw new AssertionFailure(`Timed out after ${timeoutMs}ms waiting for: ${description} (last value: ${JSON.stringify(last)})`);
+}
+
+// Full-page navigation waits on the actual CDP load event rather than
+// polling document.readyState -- polling right after a client-side
+// location.reload() can race and read the OLD document's already-"complete"
+// state before the reload has actually started.
+async function navigateAndWaitForLoad(cdp, url, timeoutMs = 30000) {
+  const loaded = cdp.once("Page.loadEventFired", timeoutMs, `page load: ${url}`);
+  const nav = await cdp.send("Page.navigate", { url });
+  if (nav.errorText) throw new EnvironmentError(`Page.navigate to ${url} failed: ${nav.errorText}`);
+  await loaded;
+}
+
+// Same idea, but for a navigation triggered by in-page JS (the burner
+// wallet's window.location.reload() after selecting an account) rather
+// than by us calling Page.navigate.
+function waitForNextLoad(cdp, timeoutMs, description) {
+  return cdp.once("Page.loadEventFired", timeoutMs, description);
+}
+
+async function screenshot(cdp, name) {
+  const { data } = await cdp.send("Page.captureScreenshot", { format: "png" });
+  const filePath = path.join(ARTIFACT_DIR, `${name}.png`);
+  fs.writeFileSync(filePath, Buffer.from(data, "base64"));
+  return filePath;
+}
+
+// ---------------------------------------------------------------------------
+// Background block miner (for the pagination-under-live-blocks check)
+// ---------------------------------------------------------------------------
+
+function startMiner() {
+  const script = `
+    while true; do
+      cast send --rpc-url ${RPC_URL} --private-key ${MINER_PRIVATE_KEY} --value 0 ${MINER_TO_ADDRESS} >/dev/null 2>&1
+      sleep 1
+    done
+  `;
+  return spawn("bash", ["-c", script], { stdio: "ignore" });
+}
+
+function stopMiner(miner) {
+  if (miner && miner.exitCode === null) {
+    try {
+      miner.kill("SIGKILL");
+    } catch {
+      /* already gone */
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  log(`Probing for a free Chrome debugging port starting at 9222...`);
+  const debugPort = await findFreePort(9222);
+  log(`Chosen debugging port: ${debugPort}`);
+
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "smoke-test-chrome-"));
+  log(`Launching Chrome (${HEADLESS ? "headless" : "headful"}), profile dir: ${userDataDir}`);
+  const chrome = launchChrome(debugPort, userDataDir);
+  // From this point on, if anything throws, the catch handler below needs
+  // enough to leave Chrome alive and record it in the shared state file --
+  // same "preserve failure state for debugging" policy as Step 8.
+  chromeHandleForFailure = { pid: chrome.pid, debugPort, userDataDir };
+
+  await waitForCdpReady(debugPort);
+  log(`Chrome CDP endpoint ready on port ${debugPort} (PID ${chrome.pid})`);
+
+  const newTabRes = await fetch(`http://127.0.0.1:${debugPort}/json/new?about:blank`, { method: "PUT" });
+  if (!newTabRes.ok) {
+    throw new EnvironmentError(`PUT /json/new failed with HTTP ${newTabRes.status}`);
+  }
+  const tab = await newTabRes.json();
+  if (!tab.webSocketDebuggerUrl) {
+    throw new EnvironmentError(`New tab has no webSocketDebuggerUrl: ${JSON.stringify(tab)}`);
+  }
+
+  const ws = new WebSocket(tab.webSocketDebuggerUrl);
+  await new Promise((resolve, reject) => {
+    ws.addEventListener("open", () => resolve(), { once: true });
+    ws.addEventListener("error", err => reject(new EnvironmentError(`WebSocket connect failed: ${err.message}`)), {
+      once: true,
+    });
+  });
+  const cdp = new CDP(ws);
+  await cdp.send("Page.enable");
+  await cdp.send("Runtime.enable");
+  await cdp.send("Log.enable");
+  log(`CDP session attached to tab ${tab.id}`);
+
+  // Dev-overlay/console advisory: register BEFORE any navigation so it
+  // captures the whole session, not just messages after some later point.
+  // See printDevOverlayAdvisory() for what happens with what's collected.
+  cdp.on("Log.entryAdded", params => {
+    if (params.entry.level !== "error") return;
+    // entry.text alone is often a generic "Failed to load resource: net::ERR_FAILED" --
+    // append the URL so the signature identifies WHICH resource, not any resource.
+    const url = params.entry.url ? ` (url: ${params.entry.url})` : "";
+    recordIssue("Log", "error", `${params.entry.text}${url}`);
+  });
+  cdp.on("Runtime.consoleAPICalled", params => {
+    if (params.type !== "error" && params.type !== "warning") return;
+    recordIssue("Console", params.type, params.args.map(consoleArgText).join(" "));
+  });
+  cdp.on("Runtime.exceptionThrown", params => {
+    const desc = params.exceptionDetails.exception?.description || params.exceptionDetails.text;
+    recordIssue("Exception", "error", desc);
+  });
+  devOverlayState.advisoryRan = true;
+
+  let miner;
+
+  // 1. Navigate to /debug
+  await navigateAndWaitForLoad(cdp, `${FRONTEND_BASE}/debug`);
+  log("Navigated to /debug");
+
+  // 2. Contract rendered with its write form -- proves the deploy -> ABI ->
+  // scaffold-hooks chain reached the frontend, not just that the page
+  // returned 200.
+  await waitFor(cdp, `!!document.querySelector('[data-testid="write-function-form-setGreeting"]')`, {
+    timeoutMs: 45000,
+    description: "your-contract's setGreeting write form rendered",
+  });
+  record("contract-rendered", "PASS", "write-function-form-setGreeting present");
+
+  // 3. Read the default greeting() before connecting -- baseline for the
+  // read-back assertion later.
+  const defaultGreeting = await evaluate(
+    cdp,
+    `(() => {
+      const el = document.querySelector('[data-testid="display-variable-greeting"] [data-testid="display-variable-value"]');
+      return el ? el.textContent.trim() : null;
+    })()`,
+  );
+  // displayTxResult() JSON.stringify()s plain string results (greeting()
+  // isn't an address or hex), so the rendered text includes literal quotes.
+  const expectedDefaultGreeting = JSON.stringify("Building Unstoppable Apps!!!");
+  if (defaultGreeting !== expectedDefaultGreeting) {
+    throw new AssertionFailure(`Expected default greeting() to render as ${expectedDefaultGreeting}, got: ${JSON.stringify(defaultGreeting)}`);
+  }
+  record("default-greeting", "PASS", defaultGreeting);
+
+  // 4. Connect the burner wallet (in-page, no extension, no native dialog).
+  //
+  // Discovered while testing this script: for the arbitrumNitro network with
+  // onlyLocalBurnerWallet (scaffold.config.ts), ScaffoldEthAppWithProviders.tsx
+  // calls initBurnerPK() unconditionally on mount, and wagmi auto-reconnects
+  // the burner connector -- so the wallet is very often ALREADY connected by
+  // the time the write form renders, with no "Connect" click involved at all.
+  // Handle both: only drive the Connect -> choose-account modal flow if the
+  // Connect button actually shows up.
+  const alreadyConnected = await evaluate(
+    cdp,
+    `(() => {
+      const submitBtn = document.querySelector('[data-testid="write-function-submit"]');
+      return !document.querySelector('[data-testid="connect-wallet"]') && !!submitBtn && !submitBtn.disabled;
+    })()`,
+  );
+
+  if (alreadyConnected) {
+    record("wallet-connected", "PASS", "auto-connected on load (burner wallet, no manual Connect needed)");
+  } else {
+    const clicked = await evaluate(
+      cdp,
+      `(() => {
+        const btn = document.querySelector('[data-testid="connect-wallet"]');
+        if (!btn) return "NOT_FOUND";
+        btn.click();
+        return "CLICKED";
+      })()`,
+    );
+    if (clicked !== "CLICKED") throw new AssertionFailure(`Could not click Connect button: ${clicked}`);
+
+    await waitFor(cdp, `!!document.querySelector('[data-testid="burner-account-option"]')`, {
+      timeoutMs: 10000,
+      description: "burner account chooser modal opened",
+    });
+
+    // Register the load listener BEFORE clicking -- selecting an account
+    // calls window.location.reload() synchronously-ish, and a listener
+    // registered after the click could miss it.
+    const reloadWait = waitForNextLoad(cdp, 30000, "reload after burner account selection");
+    const selected = await evaluate(
+      cdp,
+      `(() => {
+        const btn = document.querySelector('[data-testid="burner-account-option"]');
+        if (!btn) return "NOT_FOUND";
+        btn.click();
+        return "CLICKED";
+      })()`,
+    );
+    if (selected !== "CLICKED") throw new AssertionFailure(`Could not click burner account option: ${selected}`);
+    await reloadWait;
+    log("Burner wallet selected, page reloaded");
+
+    await waitFor(
+      cdp,
+      `(() => {
+        const connectBtn = document.querySelector('[data-testid="connect-wallet"]');
+        const submitBtn = document.querySelector('[data-testid="write-function-submit"]');
+        return !connectBtn && !!submitBtn && !submitBtn.disabled;
+      })()`,
+      { timeoutMs: 30000, description: "wallet connected (Connect button gone, write form enabled)" },
+    );
+    record("wallet-connected", "PASS", "connected via explicit Connect -> choose-account flow");
+  }
+
+  // 5. Call setGreeting(<distinct value>) and let the burner wallet sign it.
+  const newGreeting = `smoke-test-${Date.now()}`;
+  const sendResult = await evaluate(
+    cdp,
+    `(() => {
+      const form = document.querySelector('[data-testid="write-function-form-setGreeting"]');
+      if (!form) return "NO_FORM";
+      const input = form.querySelector('[data-testid="function-input"]');
+      if (!input) return "NO_INPUT";
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set;
+      setter.call(input, ${JSON.stringify(newGreeting)});
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      const sendBtn = form.querySelector('[data-testid="write-function-submit"]');
+      if (!sendBtn) return "NO_SEND_BUTTON";
+      if (sendBtn.disabled) return "SEND_DISABLED";
+      sendBtn.click();
+      return "CLICKED";
+    })()`,
+  );
+  if (sendResult !== "CLICKED") throw new AssertionFailure(`Could not submit setGreeting: ${sendResult}`);
+  log(`Submitted setGreeting("${newGreeting}")`);
+
+  // 6. Wait for the tx to confirm AND read the value back -- this single
+  // poll proves both: the displayed greeting only updates after the write
+  // succeeds and the debug page's onChange-triggered refetch runs. Expect
+  // the JSON.stringify()-quoted form -- see the default-greeting check above.
+  const expectedNewGreeting = JSON.stringify(newGreeting);
+  await waitFor(
+    cdp,
+    `(() => {
+      const el = document.querySelector('[data-testid="display-variable-greeting"] [data-testid="display-variable-value"]');
+      return el && el.textContent.trim() === ${JSON.stringify(expectedNewGreeting)};
+    })()`,
+    { timeoutMs: 60000, description: `greeting() read-back equals ${expectedNewGreeting}` },
+  );
+  record("write-and-readback", "PASS", `greeting() == ${expectedNewGreeting}`);
+
+  const debugScreenshot = await screenshot(cdp, "debug-readback");
+  log(`Screenshot: ${debugScreenshot}`);
+
+  // 7. Block explorer: page through blocks while the devnode mines
+  // continuously, confirming rows don't shift/duplicate/blank (the
+  // regression this run exists to catch -- see 351a34a).
+  await navigateAndWaitForLoad(cdp, `${FRONTEND_BASE}/blockexplorer`);
+  await waitFor(cdp, `!!document.querySelector('[data-testid="blockexplorer-table"]')`, {
+    timeoutMs: 30000,
+    description: "block explorer table rendered",
+  });
+
+  miner = startMiner();
+  log("Started background miner (1 tx/s) to keep blocks flowing during pagination");
+
+  // Read each row's block number (for the blank-cell check) AND its
+  // transaction hash (via the row's link to /blockexplorer/transaction/<hash>).
+  // Block number alone is not a valid duplicate-row signal: when a block's
+  // transactions straddle a page boundary, the same block number legitimately
+  // appears on both pages for two DIFFERENT transactions. Hash identity is
+  // what "duplicate row" actually means.
+  const readRows = `(() => Array.from(document.querySelectorAll('[data-testid="blockexplorer-row"]')).map(row => {
+    const blockNum = row.querySelector('[data-testid="blockexplorer-block-number"]')?.textContent.trim() ?? "";
+    const link = row.querySelector('a[href*="/blockexplorer/transaction/"]');
+    const hash = link ? link.getAttribute("href").split("/").pop() : "";
+    return { blockNum, hash };
+  }))()`;
+  const page1Rows = await evaluate(cdp, readRows);
+  if (!page1Rows.length) {
+    stopMiner(miner);
+    throw new AssertionFailure("Block explorer page 1 rendered no rows -- expected at least the deploy/write transactions");
+  }
+  if (page1Rows.some(r => r.blockNum === "" || r.hash === "")) {
+    stopMiner(miner);
+    throw new AssertionFailure(`Block explorer page 1 has a blank block-number or tx-hash cell: ${JSON.stringify(page1Rows)}`);
+  }
+  log(`Page 1 rows: ${JSON.stringify(page1Rows)}`);
+
+  const page1Label = await evaluate(
+    cdp,
+    `document.querySelector('[data-testid="blockexplorer-page-label"]').textContent.trim()`,
+  );
+  const page1RowsJson = JSON.stringify(page1Rows);
+
+  const nextClicked = await evaluate(
+    cdp,
+    `(() => {
+      const btn = document.querySelector('[data-testid="blockexplorer-next-page"]');
+      if (!btn) return "NO_BUTTON";
+      if (btn.disabled) return "DISABLED";
+      btn.click();
+      return "CLICKED";
+    })()`,
+  );
+
+  if (nextClicked === "DISABLED") {
+    log("Next-page button disabled (fewer blocks than fit on one page) -- pagination check inconclusive, not failed");
+    record("blockexplorer-pagination", "SKIP", "only one page of blocks available");
+  } else if (nextClicked !== "CLICKED") {
+    stopMiner(miner);
+    throw new AssertionFailure(`Could not click block explorer next-page button: ${nextClicked}`);
+  } else {
+    // Wait for BOTH the page label to advance AND the row data itself to
+    // change from page 1's snapshot. The label is cheap React state that
+    // commits synchronously on click; the table's row data depends on an
+    // async re-fetch (walks blocks backward from the pagination anchor over
+    // the websocket RPC) that lands on a LATER render. Waiting on the label
+    // alone races ahead of that re-fetch and can read page 1's stale rows
+    // under an already-updated "Page 2" label -- confirmed via manual replay
+    // against the live stack: immediately after the label flip the rows were
+    // still byte-identical to page 1, and ~2s later (still no further click)
+    // they had settled into the correct, non-duplicate page 2 rows.
+    await waitFor(
+      cdp,
+      `(() => {
+        const label = document.querySelector('[data-testid="blockexplorer-page-label"]')?.textContent.trim();
+        if (label === ${JSON.stringify(page1Label)}) return false;
+        const rows = ${readRows};
+        return JSON.stringify(rows) !== ${JSON.stringify(page1RowsJson)};
+      })()`,
+      { timeoutMs: 15000, description: "page label advanced past page 1 AND row data refreshed to new content" },
+    );
+    const page2Rows = await evaluate(cdp, readRows);
+    log(`Page 2 rows: ${JSON.stringify(page2Rows)}`);
+
+    if (!page2Rows.length) {
+      stopMiner(miner);
+      throw new AssertionFailure("Block explorer page 2 rendered no rows after a successful page-forward click");
+    }
+    if (page2Rows.some(r => r.blockNum === "" || r.hash === "")) {
+      stopMiner(miner);
+      throw new AssertionFailure(`Block explorer page 2 has a blank block-number or tx-hash cell: ${JSON.stringify(page2Rows)}`);
+    }
+    const page1Hashes = page1Rows.map(r => r.hash);
+    const page2Hashes = page2Rows.map(r => r.hash);
+    const overlap = page2Hashes.filter(h => page1Hashes.includes(h));
+    if (overlap.length) {
+      stopMiner(miner);
+      throw new AssertionFailure(`Block explorer pages 1 and 2 share transaction(s) ${JSON.stringify(overlap)} -- pagination is duplicating rows under live mining`);
+    }
+    record("blockexplorer-pagination", "PASS", "page 2 has no blank/duplicate rows vs page 1, despite continuous mining");
+  }
+
+  stopMiner(miner);
+
+  const explorerScreenshot = await screenshot(cdp, "blockexplorer-pagination");
+  log(`Screenshot: ${explorerScreenshot}`);
+
+  // 8. Homepage -- console/overlay coverage only, no new hard assertion
+  // beyond "it rendered". The burner wallet is already connected by this
+  // point (step 4), so the homepage's <Address address={connectedAddress} />
+  // renders for real here, unlike /debug and /blockexplorer which never
+  // show it -- this is the page where the ENS name/avatar lookups in
+  // Address.tsx actually fire, and the whole reason that codepath went
+  // unseen by this script before.
+  await navigateAndWaitForLoad(cdp, `${FRONTEND_BASE}/`);
+  await waitFor(cdp, `document.body.textContent.includes("Scaffold-Stylus")`, {
+    timeoutMs: 30000,
+    description: "homepage rendered",
+  });
+  record("homepage-rendered", "PASS", "homepage loaded, console/overlay coverage collected");
+  const homepageScreenshot = await screenshot(cdp, "homepage");
+  log(`Screenshot: ${homepageScreenshot}`);
+
+  // Dev-overlay/console advisory: best-effort DOM read, after the full flow
+  // has run so the overlay has had every chance to have picked something up.
+  // Failure here is caught, not thrown -- an advisory that can crash Step 7
+  // would no longer be advisory. See printDevOverlayAdvisory() at exit.
+  try {
+    devOverlayState.overlayCheck = await checkDevOverlay(cdp);
+  } catch (err) {
+    devOverlayState.overlayCheckError = err;
+  }
+
+  // Clean shutdown: close our tab, then kill Chrome and its temp profile.
+  await fetch(`http://127.0.0.1:${debugPort}/json/close/${tab.id}`).catch(() => {});
+  await killChromeGroup(chrome.pid);
+  fs.rmSync(userDataDir, { recursive: true, force: true });
+  unsetState("chromePid");
+  unsetState("chromeDebugPort");
+  unsetState("chromeUserDataDir");
+
+  return { debugScreenshot, explorerScreenshot, homepageScreenshot };
+}
+
+async function killChromeGroup(pid) {
+  try {
+    process.kill(-pid, "SIGTERM");
+  } catch {
+    /* already gone */
+  }
+  await sleep(1000);
+  try {
+    process.kill(-pid, "SIGKILL");
+  } catch {
+    /* already gone */
+  }
+}
+
+let chromeHandleForFailure = null;
+
+main()
+  .then(({ debugScreenshot, explorerScreenshot, homepageScreenshot }) => {
+    console.log("");
+    console.log("=== Step 7 results ===");
+    for (const r of results) console.log(`${r.status}: ${r.name}${r.detail ? ` (${r.detail})` : ""}`);
+    console.log(`Screenshots: ${debugScreenshot}, ${explorerScreenshot}, ${homepageScreenshot}`);
+    printDevOverlayAdvisory();
+    console.log("RESULT: PASS");
+    process.exit(0);
+  })
+  .catch(async err => {
+    console.log("");
+    console.log("=== Step 7 results ===");
+    for (const r of results) console.log(`${r.status}: ${r.name}${r.detail ? ` (${r.detail})` : ""}`);
+    printDevOverlayAdvisory();
+
+    const isEnvIssue = err instanceof EnvironmentError;
+    console.log(`RESULT: ${isEnvIssue ? "INCONCLUSIVE" : "FAIL"}: ${err.message}`);
+
+    if (chromeHandleForFailure) {
+      const { pid, debugPort, userDataDir } = chromeHandleForFailure;
+      setState("chromePid", pid);
+      setState("chromeDebugPort", debugPort);
+      setState("chromeUserDataDir", userDataDir);
+      console.log(`Chrome left running for debugging: PID=${pid} debugPort=${debugPort} profileDir=${userDataDir}`);
+      console.log(`Inspect via: http://127.0.0.1:${debugPort}/json (or point chrome://inspect at it)`);
+      console.log(`Clean up later with: .claude/skills/smoke-test/teardown.sh`);
+    }
+
+    process.exit(isEnvIssue ? 1 : 2);
+  });

--- a/.claude/skills/smoke-test/launch-detached.mjs
+++ b/.claude/skills/smoke-test/launch-detached.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+// .claude/skills/smoke-test/launch-detached.mjs
+//
+// Launch a command detached from the invoking shell/session, so it survives
+// that session exiting. Without this, Step 2 (devnode) and Step 6 (frontend)
+// were plain `cmd &` background jobs that die with the process group of
+// whatever session started them -- e.g. the invoking shell or session being
+// closed -- which made Step 8's FAIL-path escape hatch print PIDs that were
+// already dead by the time a human read them.
+//
+// Uses Node's `detached` spawn option rather than shelling out to the
+// `setsid` CLI binary: libuv calls setsid(2) directly on POSIX platforms
+// when detached is set, and this works identically on macOS and Linux --
+// unlike `setsid(1)`, which ships with util-linux and is NOT present on
+// macOS by default.
+//
+// Prints exactly the resulting PID to stdout on success (nothing else), so
+// callers can do: PID=$(node launch-detached.mjs logfile.log some-command args...)
+//
+// Usage: node launch-detached.mjs <logfile> <command> [args...]
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+
+const [, , logfile, cmd, ...args] = process.argv;
+
+if (!logfile || !cmd) {
+  console.error("usage: launch-detached.mjs <logfile> <command> [args...]");
+  process.exit(1);
+}
+
+const out = fs.openSync(logfile, "a");
+const child = spawn(cmd, args, {
+  detached: true,
+  stdio: ["ignore", out, out],
+});
+
+child.on("error", err => {
+  console.error(`ERROR: failed to launch ${cmd}: ${err.message}`);
+  process.exit(1);
+});
+
+// Give a synchronous spawn error (e.g. ENOENT) a tick to surface via the
+// error handler above before we report a PID that never actually ran.
+setImmediate(() => {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    console.error(`ERROR: ${cmd} exited immediately (code=${child.exitCode} signal=${child.signalCode})`);
+    process.exit(1);
+  }
+  child.unref();
+  process.stdout.write(String(child.pid));
+});

--- a/.claude/skills/smoke-test/preflight.sh
+++ b/.claude/skills/smoke-test/preflight.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# .claude/skills/smoke-test/preflight.sh
+#
+# Preflight for the Phase 1.5 smoke-test skill. Every check here maps to a
+# (b) DID NOT RUN reason in the skill's tri-state report — a failure here
+# means a prerequisite is missing, NOT that the smoke test itself failed.
+# This script never starts docker, deploys a contract, or touches repo
+# source; it only verifies the environment is ready to attempt Step 0-8.
+#
+# Exit codes:
+#   0  - all checks passed, safe to proceed to Step 2 (start devnode). On
+#        success this script's last line of output is `FRONTEND_PORT=<port>`
+#        — the caller must capture and export it for the rest of the run.
+#   1  - a required tool is missing
+#   2  - the consent gate (SMOKE_TEST_CONFIRM) is not set
+#   5  - the deploy-credentials gate: packages/stylus/.env is missing or has
+#        a blank/absent ACCOUNT_ADDRESS, RPC_URL, or PRIVATE_KEY for devnet
+#   3  - the fixed RPC port (8547) is already bound. This one is NOT
+#        arbitrary (see SKILL.md "DO NOT make port 8547 dynamic") so it stays
+#        a hard failure.
+#   4  - the working tree already has a dirty deployedContracts.ts / deployments
+#        artifact, meaning a prior run leaked and was never torn down
+#   6  - no free frontend port found in the probed range (3000-3019); the
+#        frontend port is arbitrary so this is only hit if 20 consecutive
+#        ports are all bound
+
+set -u
+FAILED=0
+
+check_cmd() {
+  local name="$1"
+  local hint="$2"
+  if ! command -v "$name" &>/dev/null; then
+    echo "MISSING: $name — $hint"
+    FAILED=1
+  else
+    echo "OK: $name ($(command -v "$name"))"
+  fi
+}
+
+echo "=== Tool checks ==="
+check_cmd node "install Node.js (repo uses Yarn Berry workspaces)"
+check_cmd yarn "corepack enable or npm i -g yarn"
+check_cmd docker "Docker Desktop must be installed and running"
+check_cmd cast "install Foundry (curl -L https://foundry.paradigm.xyz | bash && foundryup)"
+check_cmd cargo "install Rust via rustup"
+
+if ! cargo stylus --version &>/dev/null; then
+  echo "MISSING: cargo-stylus — cargo install cargo-stylus"
+  FAILED=1
+else
+  echo "OK: cargo-stylus ($(cargo stylus --version 2>&1 | head -1))"
+fi
+
+if [ "$FAILED" -ne 0 ]; then
+  echo ""
+  echo "Preflight FAILED: one or more required tools are missing."
+  echo "Report each missing tool's step as (b) DID NOT RUN — tool missing."
+  exit 1
+fi
+
+echo ""
+echo "=== Docker daemon check ==="
+if ! docker info &>/dev/null; then
+  echo "MISSING: docker daemon is not reachable (Docker Desktop not running?)"
+  echo "Report Step 2 (start devnode) as (b) DID NOT RUN — docker daemon unreachable."
+  exit 1
+fi
+echo "OK: docker daemon reachable"
+
+echo ""
+echo "=== Step 1a: consent gate check ==="
+if [ -z "${SMOKE_TEST_CONFIRM:-}" ]; then
+  echo "GATE CLOSED: SMOKE_TEST_CONFIRM is not set."
+  echo "This skill starts a Docker container bound to host port 8547 plus a"
+  echo "frontend dev-server port (probed from 3000), deploys throwaway"
+  echo "contracts, and drives a live browser session."
+  echo "Set SMOKE_TEST_CONFIRM=1 to explicitly opt in, then re-run."
+  echo "Report Step 1a (consent gate) as (b) DID NOT RUN — env absent."
+  exit 2
+fi
+echo "OK: SMOKE_TEST_CONFIRM=${SMOKE_TEST_CONFIRM}"
+
+echo ""
+echo "=== Step 1b: deploy-credentials gate check (packages/stylus/.env) ==="
+# 'yarn deploy' (Step 4) reads devnet ACCOUNT_ADDRESS/RPC_URL/PRIVATE_KEY
+# from this file. packages/stylus/.env.example ships the whole devnet
+# block commented out, so a fresh clone has none of these set. Checked
+# here, before Step 2 starts the devnode, so we don't bind ports and boot
+# docker only to have 'yarn deploy' die on a missing file afterward.
+#
+# This check never prints the file's contents — only which of the three
+# expected key names are present and non-blank — because the same file
+# may also hold real sepolia/mainnet secrets in other (commented) blocks.
+ENV_FILE="packages/stylus/.env"
+env_key_present() {
+  [ -f "$ENV_FILE" ] && grep -Eq "^${1}=[^[:space:]]" "$ENV_FILE"
+}
+
+MISSING_KEYS=""
+for key in ACCOUNT_ADDRESS RPC_URL PRIVATE_KEY; do
+  if ! env_key_present "$key"; then
+    MISSING_KEYS="$MISSING_KEYS $key"
+  fi
+done
+
+if [ -n "$MISSING_KEYS" ]; then
+  echo "GATE CLOSED: ${ENV_FILE} is missing or blank for:${MISSING_KEYS}"
+  echo ""
+  echo "This skill will NOT create or edit ${ENV_FILE} for you, and will"
+  echo "NOT invent or guess values. Paste this block into ${ENV_FILE}"
+  echo "(create the file if it doesn't exist) — these are the"
+  echo "nitro-devnode's own well-known prefunded dev values, hardcoded in"
+  echo "plaintext at nitro-devnode/run-dev-node.sh line 7, not a secret:"
+  echo ""
+  cat <<'BLOCK'
+DEPLOYMENT_DIR=deployments
+
+## devnet
+ACCOUNT_ADDRESS=0x3f1Eae7D46d88F08fc2F8ed27FCb2AB183EB2d0E
+RPC_URL=http://127.0.0.1:8547
+PRIVATE_KEY=0xb6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659
+BLOCK
+  echo ""
+  echo "Report Step 1b (deploy-credentials gate) as (b) DID NOT RUN — env absent."
+  exit 5
+fi
+echo "OK: ${ENV_FILE} has non-blank ACCOUNT_ADDRESS/RPC_URL/PRIVATE_KEY"
+
+echo ""
+echo "=== RPC port check (8547, fixed — not arbitrary) ==="
+if lsof -i ":8547" -sTCP:LISTEN &>/dev/null; then
+  echo "BUSY: port 8547 is already bound — a leaked devnode from a prior"
+  echo "smoke-test run is the most likely cause (check for an orphaned"
+  echo "'nitro-dev' container before retrying)."
+  FAILED=3
+else
+  echo "OK: port 8547 free"
+fi
+
+if [ "$FAILED" -ne 0 ]; then
+  echo ""
+  echo "Preflight FAILED: report the blocked step as (b) DID NOT RUN — port busy."
+  exit 3
+fi
+
+echo ""
+echo "=== Frontend port probe (3000+, arbitrary — first free port wins) ==="
+# The frontend port is not fixed like 8547 (see the RPC port check above),
+# so a busy 3000 is not a hard failure: probe upward for the first free
+# port instead of aborting. But a busy 3000 is often a dev server LEAKED
+# from a prior run of THIS skill (Step 8 teardown failed to kill it) —
+# silently sliding past it to 3001 would hide that signal and let leaks
+# pile up run after run. So for every occupied port we skip, name what
+# holds it (PID + full command) before moving on. We never kill it here —
+# only report it. A holder belonging to another project's dev server is
+# fine and expected; a holder that is this repo's own `next dev` is a
+# leak worth investigating.
+FRONTEND_PORT=""
+for offset in $(seq 0 19); do
+  candidate=$((3000 + offset))
+  holder_pid=$(lsof -nP -iTCP:"${candidate}" -sTCP:LISTEN -t 2>/dev/null | head -1)
+  if [ -z "$holder_pid" ]; then
+    FRONTEND_PORT="$candidate"
+    break
+  fi
+  holder_cmd=$(ps -p "$holder_pid" -o command= 2>/dev/null)
+  echo "port ${candidate} busy: PID ${holder_pid} ${holder_cmd}"
+done
+
+if [ -z "$FRONTEND_PORT" ]; then
+  echo "BUSY: no free port found in range 3000-3019 for the frontend."
+  echo "Report the blocked step as (b) DID NOT RUN — no free frontend port."
+  exit 6
+fi
+
+echo ""
+echo ">>> Chosen frontend port: FRONTEND_PORT=${FRONTEND_PORT} <<<"
+
+echo ""
+echo "=== Working tree cleanliness check ==="
+DIRTY=$(git status --porcelain -- packages/nextjs/contracts/deployedContracts.ts packages/stylus/deployments packages/stylus/contracts/erc20-example 2>/dev/null)
+if [ -n "$DIRTY" ]; then
+  echo "DIRTY: a previous smoke-test run left artifacts uncleaned:"
+  echo "$DIRTY"
+  echo "This means a prior run's Step 8 teardown did not complete. Clean it"
+  echo "manually (git checkout -- packages/nextjs/contracts/deployedContracts.ts;"
+  echo "rm -rf packages/stylus/deployments packages/stylus/contracts/erc20-example)"
+  echo "before treating this run's results as trustworthy."
+  exit 4
+fi
+echo "OK: no leaked artifacts from a prior run"
+
+echo ""
+echo "=== Leaked run-state check ==="
+# Step 2/6/7 launch their processes (devnode, frontend, and on a FAIL,
+# Chrome) fully detached from the invoking shell/session, so they can
+# outlive it -- see launch-detached.mjs. .smoke-state.json is the durable
+# record of that. A leftover file here is the same class of problem as the
+# dirty-tree check above: a prior run's Step 8 never ran (or never got the
+# chance to). Surfacing it directly is more useful than waiting for the
+# symptom (a busy port) to show up further down.
+STATE_FILE=".claude/skills/smoke-test/.smoke-state.json"
+if [ -f "$STATE_FILE" ]; then
+  echo "DIRTY: a previous smoke-test run's state file is still present:"
+  cat "$STATE_FILE"
+  echo "This means a prior run's Step 8 teardown did not run (FAIL/"
+  echo "INCONCLUSIVE/crash) or was never followed up by hand. Run"
+  echo "'.claude/skills/smoke-test/teardown.sh' (no arguments needed -- it"
+  echo "reads this same file) before treating this run's results as"
+  echo "trustworthy."
+  exit 4
+fi
+echo "OK: no leaked run-state file from a prior run"
+
+echo ""
+echo "Preflight PASSED. Safe to proceed to Step 2 (start devnode)."
+echo "FRONTEND_PORT=${FRONTEND_PORT}"
+exit 0

--- a/.claude/skills/smoke-test/state.mjs
+++ b/.claude/skills/smoke-test/state.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+// .claude/skills/smoke-test/state.mjs
+//
+// Shared state store for the smoke-test skill. Step 2 (devnode) and Step 6
+// (frontend) launch their processes detached from the invoking shell/session
+// via launch-detached.sh, so they survive the session that started them --
+// which means their PIDs can no longer be trusted to live only in that
+// shell's variables. This file is the durable record Step 8's teardown (and
+// a human's escape hatch) reads instead. Step 7's browser-e2e.mjs uses the
+// same file to record the Chrome it launches.
+//
+// CLI usage:
+//   node state.mjs set <key> <value>
+//   node state.mjs get <key>          # prints value, nothing if absent
+//   node state.mjs unset <key>
+//   node state.mjs dump               # pretty-prints the whole file
+//   node state.mjs clear              # deletes the state file entirely
+//
+// Library usage (imported directly by browser-e2e.mjs):
+//   import { readState, setState, unsetState, clearState } from "./state.mjs"
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const STATE_PATH = path.join(path.dirname(fileURLToPath(import.meta.url)), ".smoke-state.json");
+
+export function readState() {
+  try {
+    return JSON.parse(fs.readFileSync(STATE_PATH, "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+export function writeState(state) {
+  fs.writeFileSync(STATE_PATH, JSON.stringify(state, null, 2) + "\n");
+}
+
+export function setState(key, value) {
+  const state = readState();
+  state[key] = value;
+  writeState(state);
+}
+
+export function unsetState(key) {
+  const state = readState();
+  delete state[key];
+  writeState(state);
+}
+
+export function clearState() {
+  fs.rmSync(STATE_PATH, { force: true });
+}
+
+function main() {
+  const [, , cmd, ...args] = process.argv;
+  switch (cmd) {
+    case "set": {
+      const [key, value] = args;
+      if (!key) throw new Error("usage: state.mjs set <key> <value>");
+      setState(key, value ?? "");
+      break;
+    }
+    case "get": {
+      const [key] = args;
+      const value = readState()[key];
+      if (value !== undefined) process.stdout.write(String(value));
+      break;
+    }
+    case "unset": {
+      const [key] = args;
+      unsetState(key);
+      break;
+    }
+    case "dump":
+      console.log(JSON.stringify(readState(), null, 2));
+      break;
+    case "clear":
+      clearState();
+      break;
+    default:
+      console.error("usage: state.mjs <set|get|unset|dump|clear> [args]");
+      process.exit(1);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/.claude/skills/smoke-test/teardown.sh
+++ b/.claude/skills/smoke-test/teardown.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# .claude/skills/smoke-test/teardown.sh
+#
+# Tears down everything the smoke-test skill's Step 2 (devnode), Step 6
+# (frontend), and Step 7 (browser-e2e.mjs, on a FAIL it leaves alive) start,
+# and restores the one tracked file Step 4 legitimately modifies. Run from
+# the repo root, same as every other step in the skill.
+#
+# PIDs are read from the shared state file (.smoke-state.json, written by
+# launch-detached.mjs and browser-e2e.mjs) by default, since Step 2/6/7 now
+# launch their processes detached from the invoking shell/session -- they
+# survive that session exiting, so their PIDs cannot be trusted to live only
+# in shell variables anymore. NEXTJS_PID/CHAIN_PID env vars still override
+# the state file, for the documented manual escape-hatch invocation.
+#
+# Idempotent by design: safe to run twice, safe to run when nothing is
+# alive. Killing an already-dead PID and removing an already-absent
+# container both no-op quietly here — nothing in this script is allowed
+# to start erroring on a repeat run. No state file (or one with no live
+# PIDs) means there's simply nothing to do.
+#
+# Usage — on a PASS, Step 8 calls this automatically with no arguments. On
+# FAIL, INCONCLUSIVE, or a crash partway through, Step 8 deliberately skips
+# this call so the failure state stays alive to debug; run it by hand once
+# you're done — no arguments needed (reads the state file), or with
+# explicit PIDs from that run's escape-hatch output if you prefer:
+#
+#   .claude/skills/smoke-test/teardown.sh
+#   NEXTJS_PID=<pid> CHAIN_PID=<pid> .claude/skills/smoke-test/teardown.sh
+
+set -u
+
+STATE_SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/state.mjs"
+state_get() { node "$STATE_SCRIPT" get "$1" 2>/dev/null; }
+
+NEXTJS_PID="${NEXTJS_PID:-$(state_get nextjsPid)}"
+CHAIN_PID="${CHAIN_PID:-$(state_get chainPid)}"
+CHROME_PID="$(state_get chromePid)"
+CHROME_PROFILE_DIR="$(state_get chromeUserDataDir)"
+
+# 1. Kill the Next.js dev server — the captured PID only. Never a
+# pattern match (pkill -f "next dev" would sweep the whole machine and
+# could kill an unrelated project's dev server — this happened live).
+if [ -n "$NEXTJS_PID" ]; then
+  kill "$NEXTJS_PID" 2>/dev/null
+  sleep 2
+  kill -9 "$NEXTJS_PID" 2>/dev/null
+fi
+
+# 2. Tear down the devnode container — names one specific container, not
+# a pattern; suppressed so a second run (container already gone) doesn't
+# print a docker error.
+docker rm -f nitro-dev >/dev/null 2>&1 || true
+
+# 3. Kill the backgrounded chain script if still around
+if [ -n "$CHAIN_PID" ]; then
+  kill "$CHAIN_PID" 2>/dev/null
+fi
+
+# 3b. Kill the Chrome instance Step 7's browser-e2e.mjs left running (only
+# set in the state file when a run FAILED and left it alive for debugging;
+# a PASS run cleans up its own Chrome directly). Signal the whole process
+# GROUP, not just the one PID -- Chrome is multi-process (renderer/GPU/
+# utility children share its pgid since it was launched detached, i.e. as
+# its own group leader), and killing only the main PID would leak the rest.
+if [ -n "$CHROME_PID" ]; then
+  kill -TERM -- -"$CHROME_PID" 2>/dev/null
+  sleep 1
+  kill -KILL -- -"$CHROME_PID" 2>/dev/null
+fi
+[ -n "$CHROME_PROFILE_DIR" ] && rm -rf "$CHROME_PROFILE_DIR"
+
+# 4. Remove the Step 5 scratch fixture — never let it reach git status
+rm -rf packages/stylus/contracts/erc20-example
+
+# 5. Restore the tracked file Step 4 legitimately modified
+git checkout -- packages/nextjs/contracts/deployedContracts.ts 2>/dev/null || true
+
+# 6. Remove the gitignored deployment artifacts Step 4 wrote
+rm -rf packages/stylus/deployments
+
+# 7. Verify no orphaned processes or dirty tree remain FROM THIS RUN.
+# Scoped to the PIDs this run owns, not a name pattern — a pgrep -f
+# "next dev" here would match any other project's dev server and
+# misreport this run's teardown as failed.
+echo "=== Teardown verification (expect no output below) ==="
+docker ps -a --filter name=nitro-dev --format '{{.Names}}'
+[ -n "$NEXTJS_PID" ] && kill -0 "$NEXTJS_PID" 2>/dev/null && echo "LEAKED: NEXTJS_PID $NEXTJS_PID still alive"
+[ -n "$CHAIN_PID" ] && kill -0 "$CHAIN_PID" 2>/dev/null && echo "LEAKED: CHAIN_PID $CHAIN_PID still alive"
+[ -n "$CHROME_PID" ] && kill -0 "$CHROME_PID" 2>/dev/null && echo "LEAKED: CHROME_PID $CHROME_PID still alive"
+git status --porcelain -- packages/nextjs/contracts/deployedContracts.ts \
+  packages/stylus/deployments packages/stylus/contracts/erc20-example
+echo "=== Teardown complete ==="
+
+# 8. Clear the state file now that everything it referenced is torn down.
+node "$STATE_SCRIPT" clear 2>/dev/null || true

--- a/.claude/skills/update-check/SKILL.md
+++ b/.claude/skills/update-check/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: update-check
+description: Phase 1 — audit the MAIN scaffold project for anything needing an update across four axes: Rust/Stylus toolchain, Next.js frontend deps, security advisories, and UI libraries + upstream scaffold-eth-2 parity. Use when asked "does anything need updating?", "are we behind scaffold-eth?", "any security issues?", "does the UI need updating?", before a release, or when resuming after time away. Read-only; produces a ranked plan, changes nothing. Phase 2 (siblings) is a separate skill and must not run until phase 1 is green.
+---
+
+# Update Check — Phase 1 (main project)
+
+Covers four axes, not just dependencies: **Rust/Stylus**, **frontend deps**, **security**, and
+**UI + upstream scaffold-eth-2 parity**.
+
+Audits **this repo only**. Siblings are phase 2 and are explicitly out of scope — do not touch
+`create-stylus`, `create-stylus-extensions`, or the docs repo here.
+
+## Rule
+
+This skill is **read-only**. It never edits, commits, upgrades, or regenerates a lockfile. Its output is a
+ranked plan. Applying anything from that plan is a separate, delegated task.
+
+## Run it
+
+```
+Workflow({ scriptPath: ".claude/skills/update-check/phase1-main.mjs" })
+```
+
+The script resolves the repo root itself via `git rev-parse --show-toplevel` — it carries no absolute paths and
+works from any clone.
+
+## What it checks — 4 parallel dimensions
+
+| Dimension | Covers |
+|---|---|
+| `rust-stylus` | `stylus-sdk`, `openzeppelin-stylus`, `alloy-primitives`, `alloy-sol-types`, `cargo-stylus`, `rust-toolchain.toml` |
+| `frontend-deps` | `next`, `react`, `viem`, `wagmi`, `rainbowkit`, `typescript` and other core runtime deps |
+| `security` | Dependabot alerts, `npm audit`, `cargo audit`, CVEs against the pinned versions |
+| `ui-se2-parity` | tailwind/daisyui majors, in-flight dependency branches, and upstream scaffold-eth-2 divergence |
+
+## Constraints the script enforces
+
+These are injected into every agent prompt. A recommendation that violates one is **wrong**, not a finding.
+
+- `rust-toolchain.toml` pins **1.89.0**. Every `cargo-stylus` from **0.10.3** up needs **rustc ≥ 1.91.0**, so
+  bumping the CLI *forces* a toolchain migration. Treat it as coupled work, never a standalone bump.
+- **Never** run `cargo generate-lockfile`. `parity-scale-codec` is pinned at 3.7.5; the CI gate is
+  `cargo metadata --locked`.
+- `cargo build` on the **host** target fails on the openzeppelin-stylus 0.3.0 / stylus-sdk 0.9.0 VM mismatch.
+  Expected and pre-existing — `cargo stylus check` and wasm pass. Not a bug.
+- A different rustc changes wasm codegen, which changes **contract size**. Contracts over 24KB become
+  multi-fragment and need ArbOS 60 to activate, so size is load-bearing.
+- Merging to `main` **auto-publishes `create-stylus` to npm**. Anything landed ships to users immediately.
+- **Never infer a PR's or branch's content from its name.** A branch called `chore/cargo-stylus-0.10.8` may not
+  actually bump anything to 0.10.8 — read the real diff (`git diff origin/main...<branch>` / `gh pr diff`) and
+  quote what's actually there. A claim about PR/branch contents not backed by a diff the agent actually read is
+  a guess, not a finding. (This is the exact failure that produced a false "split PR #81, drop the 0.10.8 half"
+  recommendation on 2026-07-21 — the agent read the branch name, not the diff.)
+- **A version gap is not a finding — the changelog is.** Reporting "current X, latest Y" is an observation, not
+  a finding. For any gap, read the release notes for every intervening version, not just the newest, and state
+  what actually changed and whether it affects this project. Bare version numbers with no changelog read is a
+  failed audit, not a complete one.
+
+### Verified baseline
+
+The constraint block also carries a **verified baseline**, dated **2026-07-21**, of facts that were confirmed
+true on that run — OZ-stylus 0.3.0 still latest with no upstream VM-mismatch fix, the tailwind/daisyui majors
+already landed in PR #67, wagmi 3.x still blocked, and the one Stylus contract's compressed size (20,756 bytes
+against a 24,576 threshold). Agents are told to diff against these numbers instead of re-deriving them each run.
+**Whenever a run re-confirms or invalidates an entry, update the baseline block in `phase1-main.mjs` with a new
+verification date** — a stale, undated baseline is worse than no baseline.
+
+## Reading the output
+
+Findings are ranked security-first, then grouped:
+
+- **INDEPENDENT** — can ship on its own.
+- **COUPLED** — forces another change (e.g. cargo-stylus → rust-toolchain). Needs its own planned task with
+  re-verification of contract sizes, OZ compat, and an extension deploy. Never a drive-by bump.
+
+The report also lists what was checked and found **current**, so cleared ground is distinguishable from
+skipped ground.
+
+## Security results — three states, never conflated
+
+The script forces each security result into one of these. Read them carefully:
+
+1. scanner **ran** and found nothing
+2. scanner **did not run** — not installed, disabled, or 403
+3. vulnerability found but **not exploitable** in this codebase's usage
+
+State 2 is not "clean". A green report from a scanner that never ran proves nothing — treat it as an unchecked
+dimension and say so.
+
+## Tool traps
+
+Injected into the `security` dimension prompt specifically — each has produced a wrong result on a real run, so
+the consequence is stated alongside the instruction rather than left implicit:
+
+- `gh api ... --paginate` is **mandatory** on the Dependabot alerts endpoint. Measured on a sibling repo: 25
+  alerts without `--paginate` vs 29 with it. Omitting it silently **under-reports**, and the missing alerts look
+  like a clean result instead of a gap.
+- `gh release list` sorts by **date**, not "latest stable" — a pre-release published after the last stable tag
+  sorts above it. Use `--exclude-pre-releases`, or a pre-release gets reported as the current latest version.
+- `npm view <pkg> version` returns the latest **dist-tag**, which can lag the newest published version. Don't
+  treat it as ground truth for "is there something newer".
+- A wrong GitHub org/repo in a query fails in a way that is **indistinguishable from "no alerts found"**. Verify
+  the org/repo resolved from `git remote get-url origin` before trusting a clean result.
+- The GitHub dependency graph can be **unpopulated** while Dependabot alerts are enabled. When that happens, the
+  alerts endpoint returns `[]` and `GET /repos/{owner}/{repo}/dependency-graph/sbom` 404s. An empty alerts
+  response in that state is an artifact of an unpopulated graph, not a clean result — confirm the SBOM endpoint
+  returns 200 before trusting an empty alerts list. Proof this matters: discovered on the 2026-07-21 run, this
+  repo's tree provably contains `postcss` 8.4.31 (GHSA-qx2v-qp2m-jg93), which Dependabot should have flagged and
+  did not.
+
+## End-of-run disclosure — what did NOT run
+
+The synthesis step's output schema has a mandatory `notRunOrUnchecked` field, separate from `findings`. It must
+list every scanner, tool, or data source that did not execute or could not be verified that run — e.g.
+"cargo-audit not installed", "GitHub dependency graph unpopulated". This is a first-class section of the report,
+not something folded into a finding or left as an implicit omission; it must be impossible to overlook.
+
+## After the run
+
+1. Report the verdict, security findings first.
+2. Report what did **not** run (the `notRunOrUnchecked` section) as clearly as what did.
+3. For anything actionable, delegate the change or apply it as a separate task — this skill does not apply changes.
+4. Confirm the main project is green **before** moving to phase 2 (siblings).

--- a/.claude/skills/update-check/phase1-main.mjs
+++ b/.claude/skills/update-check/phase1-main.mjs
@@ -1,0 +1,285 @@
+export const meta = {
+  name: 'dependency-check-phase1',
+  description: 'Phase 1 — audit the main scaffold project for dependency updates: Rust/Stylus, frontend, security, UI + upstream parity',
+  whenToUse: 'Before a release, when resuming after time away, or whenever asked whether dependencies need updating. Main repo only; siblings are phase 2.',
+  phases: [
+    { title: 'Scan', detail: 'parallel: rust-stylus, frontend-deps, security, ui-se2-parity' },
+    { title: 'Report', detail: 'merge into one security-first ranked upgrade plan' },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// Portability: no absolute paths. Every agent resolves the repo itself.
+// ---------------------------------------------------------------------------
+
+const ROOT_CMD = 'git rev-parse --show-toplevel'
+
+const PREAMBLE = `You are auditing the MAIN scaffold repository. Resolve its path yourself by running:
+  ${ROOT_CMD}
+Use that as the repo root for every path below. Do NOT assume any absolute path.
+
+SCOPE — this repo ONLY. Sibling repos (create-stylus, create-stylus-extensions, the docs site) are phase 2 and
+are explicitly OUT OF SCOPE. Do not read, clone, or report on them.
+
+READ-ONLY — do not edit files, do not commit, do not upgrade anything, and do not run any command that would
+rewrite a lockfile. If the only way to gather a data point would mutate a file, skip it and say why.`
+
+const VERIFIED_BASELINE = `
+VERIFIED BASELINE — last confirmed 2026-07-21. Treat these as established facts, not open questions to
+re-derive. On every run: check whether anything below has actually changed; if so, update this block (bump the
+verification date) and report the change as a finding. If nothing has changed, DIFF against these numbers —
+re-confirm briefly, don't re-litigate them from scratch as if they were unknown.
+- openzeppelin-stylus 0.3.0 is still the latest release (shipped 2025-09-10, ~10 months old as of this date). OZ's
+  main branch still pins stylus-sdk "=0.9.0" and alloy "=0.8.20". The host-target VM mismatch (0.3.0/0.9.0) has
+  NO upstream fix yet.
+- The tailwind v3->v4 and daisyui v4->v5 migrations already LANDED (PR #67, merged 2026-06-09). Do not re-propose
+  them as pending work — just verify they are still applied.
+- wagmi 3.x is BLOCKED: no rainbowkit 3.x release exists, burner-connector hard-depends on wagmi 2.19.5, and
+  wagmi 3 requires typescript >=5.9.3 while this repo resolves 5.9.2.
+- Exactly ONE Stylus contract exists in this repo: packages/stylus/contracts/your-contract. On rustc 1.89.0 it
+  measures 20,756 bytes compressed against the 24,576-byte multi-fragment threshold. Re-measure and report the
+  delta from 20,756, not a bare fresh number treated as if no prior baseline existed.
+Whoever edits this block on a future run MUST replace the verification date above with the date of that run.`
+
+const CONSTRAINTS = `
+KNOWN CONSTRAINTS — a recommendation that violates any of these is WRONG, not a finding:
+- rust-toolchain.toml pins channel "1.89.0". EVERY cargo-stylus release from 0.10.3 up requires rustc >= 1.91.0.
+  So bumping cargo-stylus REQUIRES a rust-toolchain migration. Report it as COUPLED work, never a simple bump.
+- NEVER run 'cargo generate-lockfile'. parity-scale-codec is pinned at 3.7.5; the CI gate is
+  'cargo metadata --locked'.
+- Plain 'cargo build' on the HOST target FAILS due to an openzeppelin-stylus 0.3.0 / stylus-sdk 0.9.0 VM
+  mismatch. EXPECTED and pre-existing. 'cargo stylus check' and the wasm target pass. Do NOT report it as a bug.
+- The rust-toolchain pin is tied to OpenZeppelin requirements and CONTRACT SIZE limits
+  (OpenZeppelin/rust-contracts-stylus issue #129). A different rustc changes wasm codegen, which changes contract
+  size; contracts over 24KB become multi-fragment and need ArbOS 60 to activate. Size is load-bearing.
+- Merging to main auto-publishes create-stylus to npm. Anything landed ships to users immediately.
+- NEVER infer a PR's or branch's actual content from its NAME. A branch called "chore/cargo-stylus-0.10.8" may
+  not actually bump anything to 0.10.8 — names can be stale, aspirational, or left over from a renamed or
+  reworked change. Before reporting what a PR or branch changes, read the REAL diff
+  ('git diff origin/main...<branch>' or 'gh pr diff <number>') and quote the version numbers you actually found
+  in it. A claim about PR/branch contents that is not backed by a diff you personally read is a guess, not a
+  finding — do not report it as one, and do not recommend splitting or altering a PR based on what its name
+  implies.
+- A VERSION GAP IS NOT A FINDING — THE CHANGELOG IS. Reporting "current X, latest Y" is an observation, not a
+  finding. For ANY gap you report, read the release notes for EVERY intervening version, not just the newest,
+  and state what actually changed and whether it affects THIS project. A report of bare version numbers has
+  FAILED and must be treated as incomplete.
+${VERIFIED_BASELINE}
+
+Do NOT recommend an upgrade merely because a newer version exists. Recommend only when the delta fixes a real
+problem or closes a security gap, and state what would break.`
+
+const FINDINGS = {
+  type: 'object', additionalProperties: false, required: ['summary', 'findings'],
+  properties: {
+    summary: { type: 'string', description: 'One sentence: does this area need action?' },
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object', additionalProperties: false,
+        required: ['name', 'current', 'latest', 'severity', 'coupling', 'payoff', 'risk', 'action'],
+        properties: {
+          name: { type: 'string' },
+          current: { type: 'string', description: 'Version actually pinned in this repo, as read from the file' },
+          latest: { type: 'string', description: 'Latest upstream release, or "n/a"' },
+          severity: { enum: ['security-critical', 'security-moderate', 'should-update', 'optional', 'blocked', 'up-to-date', 'unchecked'] },
+          coupling: { enum: ['independent', 'coupled', 'n/a'], description: '"coupled" if it forces another change' },
+          payoff: { type: 'string', description: 'What updating concretely gains. "none" if cosmetic.' },
+          risk: { type: 'string', description: 'What could break; name the specific breaking change if any' },
+          action: { type: 'string', description: 'Concrete next step, or "none"' },
+        },
+      },
+    },
+  },
+}
+
+const TOOL_TRAPS = `
+TOOL TRAPS — each of these has produced a wrong result on a real run. The consequence is stated, not just the
+instruction, because an instruction without its consequence gets skipped:
+- 'gh api ... --paginate' is MANDATORY on the Dependabot alerts endpoint. Measured on a sibling repo: 25 alerts
+  without --paginate vs 29 with it. Omitting it silently UNDER-REPORTS, and the missing alerts look like a clean
+  result instead of a gap.
+- 'gh release list' sorts by DATE, not by "latest stable" — a pre-release published after the last stable tag
+  sorts ABOVE it. Use '--exclude-pre-releases', or you will report a pre-release as the current latest version.
+- 'npm view <pkg> version' returns the latest dist-tag, which can LAG the newest published version. Do not treat
+  it as ground truth for "is there something newer".
+- A wrong GitHub org/repo in a query FAILS in a way that is INDISTINGUISHABLE from "no alerts found". Verify the
+  org/repo you resolved from 'git remote get-url origin' before trusting a clean result.
+- The GitHub dependency graph can be UNPOPULATED while Dependabot alerts are enabled. When that happens, the
+  alerts endpoint returns [] and 'GET /repos/{owner}/{repo}/dependency-graph/sbom' 404s. An empty alerts
+  response in that state is an ARTIFACT of an unpopulated graph, not a clean result — confirm the SBOM endpoint
+  returns 200 before trusting an empty alerts list. Proof this matters: discovered on the 2026-07-21 run, this
+  repo's tree provably contains postcss 8.4.31 (GHSA-qx2v-qp2m-jg93), which Dependabot should have flagged and
+  did not.`
+
+const SYNTHESIS_FINDINGS = {
+  type: 'object', additionalProperties: false, required: ['summary', 'findings', 'notRunOrUnchecked'],
+  properties: {
+    summary: FINDINGS.properties.summary,
+    findings: FINDINGS.properties.findings,
+    notRunOrUnchecked: {
+      type: 'array',
+      items: { type: 'string' },
+      description: 'MANDATORY first-class section: every scanner, tool, or data source that did NOT execute or '
+        + 'could not be verified this run (e.g. "cargo-audit not installed", "GitHub dependency graph '
+        + 'unpopulated"). Never fold these into findings or omit them. Empty array ONLY if every planned check '
+        + 'genuinely ran.',
+    },
+  },
+}
+
+const DIMENSIONS = [
+  {
+    key: 'rust-stylus',
+    prompt: `${PREAMBLE}
+
+Audit the Rust/Stylus dependency stack.
+
+Read the ACTUAL pinned versions first — never assume:
+  packages/stylus/contracts/*/Cargo.toml
+  packages/stylus/contracts/rust-toolchain.toml
+  readme.md and .github/workflows/*.yaml  (for the cargo-stylus version, which appears in several places)
+
+For EACH of stylus-sdk, openzeppelin-stylus, alloy-primitives, alloy-sol-types, cargo-stylus, and the rust
+toolchain channel: find the latest upstream release and how far behind we are. Use
+  cargo search <name> --limit 1
+  gh release list --repo OffchainLabs/stylus-sdk-rs
+  gh release list --repo OpenZeppelin/rust-contracts-stylus
+  gh release list --repo OffchainLabs/cargo-stylus
+plus web search for release notes and breaking changes.
+
+For anything behind, read the CHANGELOG and state: how many releases behind, whether the gap contains a BREAKING
+change, and whether it fixes something that has actually affected this project.
+
+FLAG PROMINENTLY if stylus-sdk or openzeppelin-stylus have shipped a version resolving the 0.3.0/0.9.0
+host-target VM mismatch — that is a genuine win and changes the calculus.
+
+Also verify the cargo-stylus version is consistent across ALL its call sites; a version that differs between
+the Dockerfile, CI, and the readme is itself a finding.
+${CONSTRAINTS}`,
+  },
+  {
+    key: 'frontend-deps',
+    prompt: `${PREAMBLE}
+
+Audit the Next.js frontend stack in packages/nextjs.
+
+Read package.json for the actual pinned versions. Then for each significant runtime dep — next, react, react-dom,
+viem, wagmi, @rainbow-me/rainbowkit, typescript, and anything else core — find the latest release and the gap.
+
+Prefer 'npm outdated' / 'yarn outdated' ONLY if it does not mutate the lockfile. If it would, read package.json
+plus the lockfile and query the registry directly with 'npm view <pkg> version'.
+
+For each meaningful gap report:
+- how many major/minor versions behind
+- whether the jump crosses a MAJOR with a documented migration guide
+- whether staying behind costs anything TODAY (a broken feature, a missing fix) versus merely being older
+- whether the dep has fallen out of its support window
+
+Say plainly which ones are fine to leave alone. A list where everything is "should update" is a failed audit.
+${CONSTRAINTS}`,
+  },
+  {
+    key: 'security',
+    prompt: `${PREAMBLE}
+
+Security audit. Report only — fix nothing.
+
+Run ALL of these and report the ACTUAL output:
+1. gh api repos/{owner}/{repo}/dependabot/alerts --paginate
+   (derive owner/repo from 'git remote get-url origin'. If it 403s or the feature is disabled, SAY SO —
+   absence of alerts because the feature is off is NOT "no alerts". If this returns an empty list, you MUST also
+   check 'gh api repos/{owner}/{repo}/dependency-graph/sbom' before treating that emptiness as clean — see TOOL
+   TRAPS below.)
+2. npm audit from packages/nextjs — use a form that does NOT modify the lockfile ('npm audit --json' against the
+   existing lockfile). If the only available form would mutate files, skip and say why.
+3. cargo audit for the Rust side. If cargo-audit is not installed, REPORT THAT — do not install it.
+4. Known CVEs against the pinned versions of next, viem, wagmi, rainbowkit, stylus-sdk (web search).
+
+For EACH advisory: package, severity, whether it is actually EXPLOITABLE given how this codebase uses it (a
+devDependency advisory, or one in an unreachable code path, is not a live exposure), and the fixed version.
+
+CRITICAL — every result must be classified as exactly one of these, and they must never be conflated:
+  (a) scanner RAN successfully and found nothing
+  (b) scanner did NOT run — not installed, disabled, permission denied
+  (c) vulnerability found but NOT exploitable in this codebase
+State which case applies for each tool you tried. A clean report from a scanner that never ran is worthless and
+must be reported as severity "unchecked", not "up-to-date".
+${TOOL_TRAPS}
+${CONSTRAINTS}`,
+  },
+  {
+    key: 'ui-se2-parity',
+    prompt: `${PREAMBLE}
+
+PART 1 — UI libraries. Read packages/nextjs/package.json for tailwindcss, daisyui, and other UI deps. Report
+current vs latest, and specifically whether a MAJOR jump is pending (daisyui v4->v5, tailwind v3->v4) and what
+that migration involves.
+
+PART 2 — in-flight work already on the remote. Run 'git branch -r' and look for dependency/UI branches; at time
+of writing 'origin/chore/deps-se2-parity' and 'origin/fix/daisyui-v5-dropdown' exist. For each such branch:
+  git log origin/main..<branch> --oneline
+  gh pr list --state all --head <branch>
+Report what it contains, its age, whether it has a PR, and whether the content looks already-landed (squashed)
+or genuinely pending. If a branch already does the work, SAY SO rather than proposing duplicate effort.
+
+PART 3 — upstream scaffold-eth-2 parity. This project is a Stylus fork of scaffold-eth-2. Compare
+packages/nextjs against https://github.com/scaffold-eth/scaffold-eth-2 using gh api or web — do NOT clone
+anything into this repo. Identify notable frontend fixes upstream has that we lack, focusing on user-visible
+things: debug UI bugs, hook fixes, component fixes. IGNORE purely cosmetic divergence and anything
+Ethereum-specific that does not apply to Stylus (different chain, different contract model).
+
+Be selective. A long list of upstream commits is not useful; three that matter is.
+${CONSTRAINTS}`,
+  },
+]
+
+phase('Scan')
+log(`Phase 1 — scanning ${DIMENSIONS.length} dimensions on the main repo`)
+
+const results = (await parallel(
+  DIMENSIONS.map((d) => () =>
+    agent(d.prompt, { label: `scan:${d.key}`, phase: 'Scan', schema: FINDINGS })
+      .then((r) => (r ? { area: d.key, ...r } : null))
+  )
+)).filter(Boolean)
+
+if (results.length < DIMENSIONS.length) {
+  log(`WARNING: ${DIMENSIONS.length - results.length} dimension(s) returned nothing — coverage is incomplete`)
+}
+
+phase('Report')
+
+const report = await agent(
+  `Synthesize a dependency upgrade plan for the main scaffold repo from these scans:
+
+${JSON.stringify(results, null, 2)}
+
+Produce a decision-ready report:
+1. One-sentence verdict: does anything NEED updating right now?
+2. SECURITY FIRST. Any exploitable advisory leads regardless of other severity. If a scanner did not actually
+   run, report that as an UNCHECKED dimension — loudly — instead of implying clean.
+3. Everything else ranked: should-update > optional > blocked > up-to-date > unchecked.
+4. Split by coupling. INDEPENDENT changes can ship alone. COUPLED changes force another change and need their
+   own planned task with re-verification (contract sizes, OZ compat, an extension deploy). Never present a
+   coupled change as a simple bump.
+5. Explicitly list what was checked and found CURRENT, so cleared ground is distinguishable from skipped ground.
+6. Note where an existing branch already covers a finding, so nobody duplicates that work.
+7. END with an explicit disclosure, populated into the notRunOrUnchecked field: every scanner, tool, or check
+   that did NOT execute this run — not installed, disabled, no access, or skipped because the only way to run it
+   would mutate a file. This is a first-class section, not a footnote — a run where cargo-audit never executed
+   or the GitHub dependency graph came back unpopulated must surface those gaps as loudly as any finding. Do not
+   let an unexecuted check quietly vanish into a clean-looking summary.
+
+Be blunt. Do not invent work. If the honest answer is "almost nothing needs updating", say exactly that.
+This is phase 1 — do NOT comment on sibling repos.`,
+  { label: 'synthesize', phase: 'Report', schema: SYNTHESIS_FINDINGS }
+)
+
+return {
+  phase: 1,
+  scope: 'main-repo-only',
+  verdict: report,
+  areas: results.map((r) => r.area),
+  notRunOrUnchecked: report.notRunOrUnchecked,
+}

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Install cargo-stylus
         run: |
           cd source_repo
-          cargo install --force --locked cargo-stylus@0.10.8
+          cargo install --force --locked cargo-stylus@0.10.2
 
       - name: Install foundry cast
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Install cargo-stylus
         run: |
           cd source_repo
-          cargo install --force --locked cargo-stylus@0.10.2
+          cargo install --force --locked cargo-stylus@0.10.8
 
       - name: Install foundry cast
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+      - release/**
 
 jobs:
   lint-and-test:
@@ -68,7 +69,7 @@ jobs:
             cargo-stylus --version
           else
             echo "Installing cargo-stylus..."
-            cargo install --force --locked cargo-stylus@0.10.2
+            cargo install --force --locked cargo-stylus@0.10.8
           fi
 
       - name: Cache Rust dependencies

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -69,7 +69,7 @@ jobs:
             cargo-stylus --version
           else
             echo "Installing cargo-stylus..."
-            cargo install --force --locked cargo-stylus@0.10.8
+            cargo install --force --locked cargo-stylus@0.10.2
           fi
 
       - name: Cache Rust dependencies

--- a/.github/workflows/release-create-stylus.yaml
+++ b/.github/workflows/release-create-stylus.yaml
@@ -87,6 +87,8 @@ jobs:
             --exclude='__test*__' \
             --exclude='CHANGELOG*' \
             --exclude='CONTRIBUTING*' \
+            --exclude='.claude/' \
+            --exclude='.worktrees/' \
             source_repo/ destination_repo/templates/base
           cd destination_repo
           git add .


### PR DESCRIPTION
## Summary

1 of 2 PRs feeding `release/v0.2.0` (split from the single-branch `release/phase-1` / PR #91 for reviewability, per Gian's feedback). This PR carries the **tooling** slice: `.claude/**` and `.github/**`.

- Adds `.claude/skills/sibling-sync`, `.claude/skills/smoke-test`, `.claude/skills/update-check`
- Updates `.github/workflows/demo.yaml` and `.github/workflows/release-create-stylus.yaml`
- **Deliberate content change**: widens `.github/workflows/lint.yaml`'s `pull_request` trigger to include `release/**` (in addition to `main`), since both this PR and PR B (2/2) target `release/v0.2.0` and would otherwise get zero CI coverage — the same gap that left PR #95 unverified previously.

See PR B (project changes): to be linked once opened.

After both PR A and PR B merge into `release/v0.2.0`, a separate PR (`release/v0.2.0` -> `main`, `[minor]`) will publish the release. That PR is out of scope here.

## Test plan

- [x] File set verified programmatically via `git diff --name-status origin/main...origin/release/phase-1 -- .claude .github`
- [ ] Confirm Lint workflow actually runs on this PR's Checks tab (trigger filter edited within this same PR — self-trigger is not guaranteed)