### PR TITLE
feat(demo-video): record a real Sepolia deploy + wallet-connect write tx

### DIFF
--- a/.claude/skills/cdp-with-wallet/SKILL.md
+++ b/.claude/skills/cdp-with-wallet/SKILL.md
@@ -44,19 +44,22 @@ does the same thing for MetaMask.
 
 | Can do | Cannot do |
 |---|---|
-| Unlock an already-initialised MetaMask vault given its password | Create a wallet, import a seed phrase, or otherwise initialise a vault (see Onboarding -- by design, not a limitation) |
+| Unlock an already-initialised MetaMask vault given its password -- **live-proven end to end** (see "Measured unknowns") | Create a wallet, import a seed phrase, or otherwise initialise a vault (see Onboarding -- by design, not a limitation) |
 | Select MetaMask's connector via EIP-6963 `rdns === "io.metamask"`, deterministically, regardless of how many other wallets are installed | Guarantee any *other* extension's popups are automatable the same way -- only MetaMask's `notification.html` shape has been reasoned about here |
-| Approve a connection or a transaction popup by finding and clicking its real button via CDP | Read or validate what a transaction actually does before approving it -- it clicks Confirm, it does not decide whether confirming is safe. Isolation (testnet-only funds, single-wallet profile) is the actual safety control, not this script's judgement |
+| Approve a connection, a `wallet_addEthereumChain` request, or a transaction popup by finding and clicking its real button via CDP -- all three use the same `confirm-footer-button`/`confirm-btn` mechanism, live-confirmed | Read or validate what a transaction actually does before approving it -- it clicks Confirm, it does not decide whether confirming is safe. Isolation (testnet-only funds, single-wallet profile) is the actual safety control, not this script's judgement |
 | Run against a dynamically-probed CDP port, so multiple runs / other Chrome usage don't collide on a fixed port | Assume `--disable-extensions-except` isolates MetaMask -- **measured false**, see below |
-| Recover from a crash mid-run via `node launch.mjs teardown` (kills leaked Chrome AND restores any extensions it disabled) | Guarantee zero risk if the *real* automation script itself crashes between disabling extensions and calling `restoreExtensions()` -- always run `node launch.mjs teardown` afterward as a matter of course, not only when something visibly went wrong |
-| Detect a not-yet-onboarded machine and say so with an exact fix command | Fix a not-yet-onboarded machine automatically -- see Onboarding |
+| Recover from a crash mid-run via `node launch.mjs teardown` (kills leaked Chrome AND restores any extensions it disabled) -- live-tested against a real crashed ad-hoc script | Guarantee zero risk if the *real* automation script itself crashes between disabling extensions and calling `restoreExtensions()` -- always run `node launch.mjs teardown` afterward as a matter of course, not only when something visibly went wrong |
+| Detect a not-yet-onboarded machine and say so with an exact fix command, INCLUDING a Keychain entry that exists but holds the wrong password (see prerequisite 4) | Fix a not-yet-onboarded machine automatically -- see Onboarding |
 
-## Measured unknowns (2026-07-22)
+## Measured unknowns
 
 The design for this skill called out four things as "measure, don't reason
-about" because each has a plausible-sounding wrong answer. Here is what was
-actually observed, live, on this machine (Chrome 150.0.7871.129, MetaMask
-13.35.1.0):
+about" because each has a plausible-sounding wrong answer. All four are now
+answered, live, on this machine (Chrome 150.0.7871.129, MetaMask 13.35.1.0) --
+the first two below during initial development (2026-07-22), the last two
+during a live, end-to-end run against Arbitrum Sepolia once a human had
+actually completed onboarding (also 2026-07-22, several hours later --
+see Onboarding for why that gap mattered):
 
 1. **`--disable-extensions-except` with an installed (not unpacked)
    extension.** Measured **false**: passing it either the installed
@@ -72,66 +75,53 @@ actually observed, live, on this machine (Chrome 150.0.7871.129, MetaMask
    own JS context. That API is available there, unrestricted, without
    toggling Developer Mode, for Web-Store-installed extensions.
 
-2. **MetaMask 13.35.1.0 selectors.** **Could not be fully verified live** --
-   see "Selector verification status" below. The onboarding screen's
-   testids (`onboarding-create-wallet`, `onboarding-import-wallet`) ARE
-   live-confirmed, since that screen was reachable. The unlock/connect/
-   confirm screens were not reachable (no initialised vault -- see
-   Onboarding), so their selectors in `metamask.mjs` are carried over from
-   MetaMask's long-stable public test-id conventions, not observed on this
-   build. **Confirm them the first time this skill runs against a real
-   unlocked account.**
+2. **MetaMask 13.35.1.0 selectors.** **Live-confirmed end to end.** Every
+   selector `metamask.mjs` uses for unlock/connect/approve is exactly what
+   was clicked in a real run (see the "LIVE-VERIFIED" block at the top of
+   that file) -- not carried over from another project or another MetaMask
+   version. Getting here surfaced two real bugs, both fixed in this PR:
+   - LavaMoat "scuttling" blocks the classic React-controlled-input trick
+     (grabbing `HTMLInputElement.prototype`'s value setter) with `Error:
+     LavaMoat - property "HTMLInputElement" of globalThis is inaccessible
+     under scuttling mode`. Fixed by focusing the element with a plain
+     `el.focus()` call and using CDP's own `Input.insertText`, which never
+     touches page globals.
+   - `unlock()`'s locked/unlocked check ran after a fixed 1500ms sleep --
+     on this machine's headless launch, the app had rendered **nothing**
+     yet at that point (zero `[data-testid]` elements at all), so the
+     check silently read "no unlock screen visible" as "already unlocked"
+     without ever testing the password. Fixed by polling for the app to
+     render something recognizable before deciding lock state, instead of
+     a fixed sleep.
 
-3. **The transient-popup race.** Designed defensively
-   (`metamask.mjs`'s `waitForTarget()` polls `GET /json/list` on a bounded
-   timeout, mirroring `browser-e2e.mjs`'s `waitFor()`), but not empirically
-   timed -- that requires a live connect/tx flow, which requires an
-   initialised vault (see Onboarding, again).
+3. **The transient-popup race.** Measured directly: the first
+   `GET /json/list` poll immediately after firing `eth_sendTransaction`
+   found no `notification.html` target at all; it appeared roughly a
+   second later. `waitForTarget()`'s poll-with-timeout design (mirroring
+   `browser-e2e.mjs`'s `waitFor()`) handled this correctly in the live run.
 
 4. **Is Arbitrum Sepolia already configured in this MetaMask instance?**
-   Measured **no**. `NetworkController.networkConfigurationsByChainId` on
-   this machine lists `0x1, 0x18c7, 0x2105, 0x279f, 0x38, 0x89, 0xa, 0xa4b1,
-   0xaa36a7, 0xe705, 0xe708` -- **no `0x66eee`** (Arbitrum Sepolia). Adding
-   it is an additional popup flow (MetaMask's "Add network" confirmation)
-   that this skill does not yet drive; plan for it before the first live
-   run against Sepolia.
+   Measured **no** -- confirmed twice, hours apart (`NetworkController.
+   networkConfigurationsByChainId` never included `0x66eee` before the live
+   run added it). Driving `wallet_addEthereumChain` from a dapp page (see
+   Procedure) pops the same confirmation-screen component `approveTx()`
+   already knows how to click (`confirm-footer-button`) -- MetaMask
+   resolved the request by both adding AND switching to the network in a
+   single confirmation, no second popup. `eth_chainId` read back `0x66eee`
+   immediately after.
 
-### Selector verification status -- read before trusting `metamask.mjs`
+### Live end-to-end proof
 
-Two independent, measured blockers prevented verifying `unlock()`,
-`connect()`, and `approveTx()`'s selectors against a real unlocked MetaMask
-instance on this machine:
+Real transaction on Arbitrum Sepolia, driven entirely through this skill's
+primitives (`unlock()` -> `wallet_addEthereumChain` + `approveTx()` ->
+`connect()` -> `eth_sendTransaction` + `approveTx()`):
 
-1. **The real debug profile's vault is not initialised.** `preflight.mjs`'s
-   check 3 does a live read of `chrome.storage.local` via the extension's
-   own service worker and found `KeyringController.vault` absent and
-   `AccountsController.internalAccounts.accounts` empty (`{}`). MetaMask's
-   own UI agrees: opening `home.html` redirects to `#/onboarding/welcome`,
-   never to an unlock screen. This directly contradicts the assumption this
-   skill was designed under ("MetaMask is already set up, only the
-   password is needed") -- a non-empty `Local Extension Settings/<id>`
-   directory (9MB+ on this machine) is **not** evidence of an initialised
-   vault; that directory holds all of `chrome.storage.local` for the
-   extension (locale, telemetry consent, feature flags, snap registries),
-   which is non-empty even for a never-onboarded install. See `preflight.mjs`
-   check 3's comment for the full reasoning -- this is exactly the kind of
-   false-positive proxy check that made smoke-test's Step 5 permanently
-   impossible, caught here before it could do the same.
-2. **A disposable substitute doesn't work either.** The obvious workaround
-   -- copy the installed extension's directory into a temp profile and load
-   it via `--load-extension` to get a throwaway wallet without touching the
-   real profile -- fails outright. Chrome's content-verification system
-   rejects it: `Content verify job failed for extension: <id> at path:
-   home.html and for reason:1` (hash mismatch), even with `_metadata/`
-   stripped from the copy. Web-Store-installed extensions cannot be
-   reloaded unpacked under their real ID on this Chrome build.
-
-Neither blocker is something this skill's code can work around -- both are
-Chrome/MetaMask platform behavior. The only path past them is a human
-completing Onboarding step 3 below (importing a seed by hand), after which
-a follow-up run should verify (and, if needed, correct) the unlock/connect/
-confirm selectors against the real unlocked instance before relying on them
-for anything unattended.
+- tx hash: `0x7c89e227ad9714a72f83925c7febcc52f5ba3e2cfddafa4d5c5773d279e0df8d`
+- https://sepolia.arbiscan.io/tx/0x7c89e227ad9714a72f83925c7febcc52f5ba3e2cfddafa4d5c5773d279e0df8d
+- `cast receipt` confirms `status: 1 (success)`, block 290078542, chainId
+  421614 (`0x66eee`), from/to `0x777d569Bd3b0A2De007097A3D7E1687C5E5EB859`
+  (the account imported in Onboarding step 3, matching
+  `ACCOUNT_ADDRESS_SEPOLIA` in `packages/stylus/.env`).
 
 ## Chrome launch contract
 
@@ -143,6 +133,16 @@ for anything unattended.
   automation run) doesn't collide.
 - No `--disable-extensions-except` (see measured unknown 1 above). Isolation
   happens post-launch via `launch.mjs`'s `isolateExtensions()`.
+- **Headless by default** (`launchChrome()`'s `headless` parameter defaults
+  to `true`). MEASURED, not assumed: Chrome's `--headless=new` mode (unlike
+  its older headless mode) runs extensions -- proven directly by this
+  skill's own preflight checks and its live end-to-end Sepolia run, both
+  driven entirely with `headless: true`. A visible window stealing focus
+  for routine automation is a real cost; the parameter stays available
+  (`headless: false`) but nothing has to opt in to get the non-disruptive
+  default. **The one case that must opt out:** screen recording -- macOS
+  `screencapture -v` cannot capture a headless window (there is no window),
+  so the `demo-video` workflow (PR 2) needs `headless: false` explicitly.
 - Select the connector by **EIP-6963 `rdns === "io.metamask"`**, never by
   button position -- the debug profile holds 5 other wallet-shaped
   extensions (Braavos, Keplr, Xverse, UniSat, and the "Ready X" smart
@@ -164,6 +164,20 @@ const { disabledIds } = await isolateExtensions(port, METAMASK_EXTENSION_ID, chr
 try {
   const password = /* read via `security find-generic-password -s stylus-demo-metamask -w`, never echoed/logged */;
   await unlock({ port, extensionId: METAMASK_EXTENSION_ID, password });
+
+  // If the target network isn't configured yet (LIVE-CONFIRMED: Arbitrum
+  // Sepolia, 0x66eee, is not preconfigured -- see "Measured unknowns"),
+  // trigger wallet_addEthereumChain from the dapp page's provider, then
+  // approve the resulting popup with the SAME primitive used for a
+  // transaction confirmation -- MetaMask renders both through the same
+  // confirmation-screen component:
+  //   dappCdp's provider.request({ method: "wallet_addEthereumChain", params: [{
+  //     chainId: "0x66eee", chainName: "Arbitrum Sepolia",
+  //     nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+  //     rpcUrls: ["https://sepolia-rollup.arbitrum.io/rpc"],
+  //     blockExplorerUrls: ["https://sepolia.arbiscan.io"],
+  //   }] })
+  await approveTx({ port, extensionId: METAMASK_EXTENSION_ID });
 
   // Navigate a separate CDP target to your dapp, attach a CDP session to it
   // (`dappCdp` below), THEN:
@@ -230,25 +244,26 @@ Run `node .claude/skills/cdp-with-wallet/preflight.mjs` first -- it checks
 every prerequisite below and SKIPs (never hard-fails) with the exact fix
 when one is missing, the same contract as smoke-test's Steps 9a/9b.
 
-**Before running `preflight.mjs` or the skill itself, fully quit any Chrome
-window open against the debug profile (Cmd+Q, not just closing the
-window).** Chrome only allows one process to hold a given `--user-data-dir`
-at a time -- MEASURED (2026-07-22): with the developer's own interactive
-Chrome still open against `$HOME/.chrome-debug-profile`, `preflight.mjs`'s
-vault check now names the exact conflicting PID and tells you to quit it;
-before that fix it surfaced as an opaque "CDP endpoint never became
-reachable (fetch failed)", which reads like a broken launcher, not a
-profile-lock conflict -- the same misdiagnosis shape as smoke-test Step
-9c's balance gate once reporting a missing `cast` binary as "Sepolia RPC
-unreachable." A fresh machine hits this on its very first run, the moment
-someone opens the debug profile by hand to check it exists.
+**Before any of this -- fully quit any Chrome window already open against
+the debug profile (Cmd+Q, not just closing the window).** Chrome only
+allows one process to hold a given `--user-data-dir` at a time. MEASURED
+(2026-07-22): with a developer's own interactive Chrome left open against
+`$HOME/.chrome-debug-profile`, `preflight.mjs`'s checks that launch their
+own Chrome can't get a CDP port up at all. Before this was fixed, that
+surfaced as an opaque "CDP endpoint never became reachable (fetch failed)",
+which reads like a broken launcher, not a profile-lock conflict -- the same
+misdiagnosis shape as smoke-test Step 9c once reporting a missing `cast`
+binary as "Sepolia RPC unreachable." `preflight.mjs` now detects this
+specific case and names the conflicting PID directly. A fresh machine hits
+this on its very first run, the moment someone opens the debug profile by
+hand to check it exists.
 
 | # | Prerequisite | Scriptable? |
 |---|---|---|
 | 1 | `$HOME/.chrome-debug-profile` exists | Yes -- `preflight.mjs` checks it |
 | 2 | MetaMask installed in that profile | Yes to check, **no** to fix -- see below |
-| 3 | MetaMask vault initialised | Yes to check (a live `chrome.storage.local` read, not a directory-size guess -- see "Selector verification status" above for why), **no** to fix -- see below |
-| 4 | Keychain item `stylus-demo-metamask` present | Yes -- existence check only, never reads the value |
+| 3 | MetaMask vault initialised | Yes to check (a live `chrome.storage.local` read, not a directory-size guess -- see below for why), **no** to fix -- see below |
+| 4 | Keychain item `stylus-demo-metamask` present **and correct** | Yes to check (a live unlock attempt, gated on 3 passing -- see below), **no** to fix -- see below |
 | 5 | Arbitrum Sepolia RPC reachable via `packages/stylus/.env`'s `RPC_URL_SEPOLIA` | Yes |
 
 **Steps 2 and 3 cannot be scripted, and should not be** -- installing a
@@ -262,18 +277,25 @@ this skill should never automate silently.
 
 **Step 3 (initialise the vault) -- read this before doing it:**
 1. Launch Chrome with the same profile and open the MetaMask extension.
-2. Choose **"I already have a wallet"** and import an **existing seed
-   phrase for a TESTNET-ONLY account** -- one that has never held, and will
-   never hold, mainnet funds. `approveTx()` signs whatever it's pointed at
-   without reading it; the only real safety boundary here is that the
-   account itself has nothing worth stealing.
-3. Set the vault password to the **same value** already stored in Keychain
-   under `stylus-demo-metamask` (see Step 4 below), so `unlock()` can use
-   it without a mismatch.
-4. Fund the account with a small amount of Arbitrum Sepolia ETH from a
-   faucet (see `readme.md`'s "Arbitrum Testnet Faucets" section).
+2. Create a new wallet (or choose "I already have a wallet" if you have a
+   seed phrase in mind) -- either way, set a password. **Note it down** --
+   step 4 needs the exact same value.
+3. **Fastest path for this repo, and what was actually done to produce
+   this PR's live-run evidence:** once the wallet exists, go to the account
+   menu -> **Import account -> Private Key**, and paste the value of
+   `PRIVATE_KEY_SEPOLIA` from `packages/stylus/.env`. That account is
+   **already funded** with Arbitrum Sepolia ETH -- no faucet trip needed,
+   and the deployer address and the MetaMask account end up identical,
+   which is convenient for matching up on-chain activity later. If you'd
+   rather import a fresh seed instead and fund it yourself, that works too
+   (see `readme.md`'s "Arbitrum Testnet Faucets" section) -- either way,
+   **this account must be TESTNET-ONLY**, one that has never held and will
+   never hold mainnet funds. `approveTx()` signs whatever it's pointed at
+   without reading it; the account having nothing worth stealing is the
+   actual safety boundary, not this skill's judgement.
 
-**Step 4 (Keychain entry):**
+**Step 4 (Keychain entry) -- and the gotcha that cost three round trips
+while building this skill:**
 ```bash
 security add-generic-password -s stylus-demo-metamask -a "$USER" -w
 ```
@@ -281,16 +303,50 @@ This prompts for the password interactively -- it is never echoed and never
 touches shell history. Do **not** pass `-w <password>` as a literal
 argument on the command line.
 
+**The Keychain entry and the MetaMask password are set at two different
+moments** -- this one now, the actual vault password back in step 3 -- **so
+nothing keeps them in sync automatically, and they will silently drift** if
+you change one without the other. This is exactly what happened while
+building this skill: a Keychain entry created early in the session held a
+26-character value; the password actually set in MetaMask during onboarding
+was 13 characters with a period; `preflight.mjs`'s old existence-only check
+reported OK regardless, and `unlock()` failed three steps later with
+MetaMask's own "incorrect password" error. `preflight.mjs` check 4 now
+performs a live unlock attempt (gated on check 3 having passed -- there is
+nothing to unlock otherwise) instead of just checking the entry exists, so
+this drift is now caught up front with an exact fix:
+```bash
+security add-generic-password -U -s stylus-demo-metamask -a "$USER" -w
+```
+(the `-U` flag updates the existing item -- a plain `add-generic-password`
+without it exits with "the specified item already exists" and changes
+nothing, which looks like success at a glance).
+
 **Step 5 (Sepolia RPC):** copy `packages/stylus/.env.example` to
 `packages/stylus/.env` if it doesn't exist, and fill in `RPC_URL_SEPOLIA` in
 the `## sepolia` block (a public endpoint such as
-`https://sepolia-rollup.arbitrum.io/rpc` works).
+`https://sepolia-rollup.arbitrum.io/rpc` works). Resolved from the git
+repository root (`git rev-parse --git-common-dir`'s parent), not
+`process.cwd()`, so this works whether `preflight.mjs` is run from the main
+checkout or from a worktree -- `.env` is untracked and only exists wherever
+a human actually put it (normally the main checkout).
 
-Every check above was verified in **both** directions where a live present
-case exists: `preflight.mjs`'s output for the induced-absent case (a
-non-existent profile dir, a non-existent Keychain service name, a
-non-existent env file) and for the real present case (this machine's
-existing profile, extension, Keychain entry) are both in this repo's PR
-description / commit evidence. Check 3 (vault) could only be verified in
-the absent direction on this machine, since no present case exists here --
-see "Selector verification status" above.
+**One more thing a fresh machine will hit on its first live run:** Arbitrum
+Sepolia is not preconfigured in MetaMask (see "Measured unknowns" #4). This
+isn't a separate manual onboarding step -- the skill drives it itself via
+`wallet_addEthereumChain` + `approveTx()`, shown in Procedure above -- but
+expect an extra confirmation popup the first time, and don't mistake it for
+a bug.
+
+Every check was verified in **all** the directions that exist for it:
+`preflight.mjs`'s raw output for the induced-absent case (a non-existent
+profile dir, a non-existent Keychain service name, a non-existent env file)
+and for the real present case are both in this PR's evidence. Check 3
+(vault) was verified in both directions on this machine, hours apart -- SKIP
+before a human completed onboarding, OK after. Check 4 (Keychain password)
+was verified in all three of its outcomes: entry absent, entry present but
+wrong (the real drift above, and separately re-confirmed with a disposable
+test Keychain entry holding a deliberately wrong value), and entry present
+and correct -- the last of these driving a real, unlocked MetaMask session
+through to a mined Arbitrum Sepolia transaction (see "Live end-to-end
+proof" above).

--- a/.claude/skills/cdp-with-wallet/SKILL.md
+++ b/.claude/skills/cdp-with-wallet/SKILL.md
@@ -230,6 +230,19 @@ Run `node .claude/skills/cdp-with-wallet/preflight.mjs` first -- it checks
 every prerequisite below and SKIPs (never hard-fails) with the exact fix
 when one is missing, the same contract as smoke-test's Steps 9a/9b.
 
+**Before running `preflight.mjs` or the skill itself, fully quit any Chrome
+window open against the debug profile (Cmd+Q, not just closing the
+window).** Chrome only allows one process to hold a given `--user-data-dir`
+at a time -- MEASURED (2026-07-22): with the developer's own interactive
+Chrome still open against `$HOME/.chrome-debug-profile`, `preflight.mjs`'s
+vault check now names the exact conflicting PID and tells you to quit it;
+before that fix it surfaced as an opaque "CDP endpoint never became
+reachable (fetch failed)", which reads like a broken launcher, not a
+profile-lock conflict -- the same misdiagnosis shape as smoke-test Step
+9c's balance gate once reporting a missing `cast` binary as "Sepolia RPC
+unreachable." A fresh machine hits this on its very first run, the moment
+someone opens the debug profile by hand to check it exists.
+
 | # | Prerequisite | Scriptable? |
 |---|---|---|
 | 1 | `$HOME/.chrome-debug-profile` exists | Yes -- `preflight.mjs` checks it |

--- a/.claude/skills/cdp-with-wallet/SKILL.md
+++ b/.claude/skills/cdp-with-wallet/SKILL.md
@@ -140,9 +140,11 @@ primitives (`unlock()` -> `wallet_addEthereumChain` + `approveTx()` ->
   driven entirely with `headless: true`. A visible window stealing focus
   for routine automation is a real cost; the parameter stays available
   (`headless: false`) but nothing has to opt in to get the non-disruptive
-  default. **The one case that must opt out:** screen recording -- macOS
-  `screencapture -v` cannot capture a headless window (there is no window),
-  so the `demo-video` workflow (PR 2) needs `headless: false` explicitly.
+  default. Recording a demo video does **not** need `headless: false` --
+  an earlier design assumed macOS `screencapture -v` (which does need a
+  real window) but that path hit a real Screen Recording TCC permission
+  gate; `demo-video` (PR 2) instead uses CDP's own `Page.startScreencast`,
+  which captures frames from inside Chrome regardless of headless state.
 - Select the connector by **EIP-6963 `rdns === "io.metamask"`**, never by
   button position -- the debug profile holds 5 other wallet-shaped
   extensions (Braavos, Keplr, Xverse, UniSat, and the "Ready X" smart

--- a/.claude/skills/cdp-with-wallet/SKILL.md
+++ b/.claude/skills/cdp-with-wallet/SKILL.md
@@ -246,6 +246,21 @@ Run `node .claude/skills/cdp-with-wallet/preflight.mjs` first -- it checks
 every prerequisite below and SKIPs (never hard-fails) with the exact fix
 when one is missing, the same contract as smoke-test's Steps 9a/9b.
 
+**Exit code is three-way, not binary** (adopted from scaffold-stark,
+2026-07-22) -- callers can rely on this to distinguish "fix your machine"
+from "try again later":
+| Exit | Meaning | Callers should |
+|---|---|---|
+| `0` | GREEN -- every prerequisite satisfied | proceed |
+| `1` | RED -- a real, fixable gap (no vault, wrong/missing Keychain entry, MetaMask not installed, etc) | block, and act on the SKIP line's fix |
+| `2` | INFRA -- every SKIP is environmental (Sepolia RPC unreachable, another Chrome window holding the debug profile) -- not a defect in this machine's setup | may choose not to block; a retry can legitimately succeed |
+
+A bare 0/1 would make a transient network blip look identical to a
+genuinely misconfigured machine -- and a gate that goes red on things
+nobody can control is a gate people learn to ignore. If BOTH categories of
+SKIP are present in the same run, exit `1` (RED) wins: a real setup gap
+still needs fixing regardless of what else happened to be flaky.
+
 **Before any of this -- fully quit any Chrome window already open against
 the debug profile (Cmd+Q, not just closing the window).** Chrome only
 allows one process to hold a given `--user-data-dir` at a time. MEASURED

--- a/.claude/skills/cdp-with-wallet/SKILL.md
+++ b/.claude/skills/cdp-with-wallet/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: cdp-with-wallet
+description: Use when a task needs a real MetaMask wallet driven end-to-end (unlock, connect via EIP-6963, approve a transaction) against a live network like Arbitrum Sepolia, without a human clicking the extension popup. Triggers on requests to automate MetaMask, drive a real wallet transaction, or record a browser demo that needs a connected wallet.
+---
+
+# cdp-with-wallet
+
+## Overview
+
+`scaffold.config.ts`'s `onlyLocalBurnerWallet: true` hides the burner wallet
+on any network other than the local devnode, so proving the frontend half of
+a real deploy (e.g. Arbitrum Sepolia) needs an actual wallet extension
+connected and signing. `smoke-test`'s Step 9 deliberately stops at
+deploy-and-read-back for exactly this reason — driving a real wallet was out
+of scope there.
+
+This skill closes that gap with raw Chrome DevTools Protocol over
+WebSocket, **zero npm dependencies**, matching the in-repo precedent
+`.claude/skills/smoke-test/browser-e2e.mjs` (same CDP client shape, same
+findFreePort/waitForCdpReady idiom). The blueprint technique is Brove's
+`packages/nextjs/e2e/helpers/braavos.ts`: enumerate CDP targets from
+`GET http://localhost:<port>/json`, find the extension's own page by URL
+prefix, attach a WebSocket directly to it. Braavos is a different extension
+with different selectors -- only the *technique* carries over.
+
+**A trap to not fall into:** Brove's `chrome-cdp-profile/SKILL.md` says
+extension popups "cannot be automated and must be clicked by hand." That is
+a limitation of Brove's page-only `agent-browser` tool, not of CDP itself --
+`braavos.ts` in that same repo automates the extension directly. This skill
+does the same thing for MetaMask.
+
+## Files
+
+```
+.claude/skills/cdp-with-wallet/
+  SKILL.md        this file
+  preflight.mjs    checks every prerequisite, SKIPs (never hard-fails) on a gap
+  launch.mjs       Chrome launcher: profile handling, dynamic CDP port, PID
+                   registry, single-wallet extension isolation
+  metamask.mjs     unlock() / connect() / approveTx() / waitForTarget()
+```
+
+## Can-do / cannot-do
+
+| Can do | Cannot do |
+|---|---|
+| Unlock an already-initialised MetaMask vault given its password | Create a wallet, import a seed phrase, or otherwise initialise a vault (see Onboarding -- by design, not a limitation) |
+| Select MetaMask's connector via EIP-6963 `rdns === "io.metamask"`, deterministically, regardless of how many other wallets are installed | Guarantee any *other* extension's popups are automatable the same way -- only MetaMask's `notification.html` shape has been reasoned about here |
+| Approve a connection or a transaction popup by finding and clicking its real button via CDP | Read or validate what a transaction actually does before approving it -- it clicks Confirm, it does not decide whether confirming is safe. Isolation (testnet-only funds, single-wallet profile) is the actual safety control, not this script's judgement |
+| Run against a dynamically-probed CDP port, so multiple runs / other Chrome usage don't collide on a fixed port | Assume `--disable-extensions-except` isolates MetaMask -- **measured false**, see below |
+| Recover from a crash mid-run via `node launch.mjs teardown` (kills leaked Chrome AND restores any extensions it disabled) | Guarantee zero risk if the *real* automation script itself crashes between disabling extensions and calling `restoreExtensions()` -- always run `node launch.mjs teardown` afterward as a matter of course, not only when something visibly went wrong |
+| Detect a not-yet-onboarded machine and say so with an exact fix command | Fix a not-yet-onboarded machine automatically -- see Onboarding |
+
+## Measured unknowns (2026-07-22)
+
+The design for this skill called out four things as "measure, don't reason
+about" because each has a plausible-sounding wrong answer. Here is what was
+actually observed, live, on this machine (Chrome 150.0.7871.129, MetaMask
+13.35.1.0):
+
+1. **`--disable-extensions-except` with an installed (not unpacked)
+   extension.** Measured **false**: passing it either the installed
+   extension's on-disk directory path or its bare extension ID disabled
+   **every** extension, including the one named -- confirmed via
+   `chrome.developerPrivate.getExtensionsInfo()` returning an empty list
+   either way. That flag's allow-list only matches extensions loaded via
+   `--load-extension` (unpacked/dev-mode); it does not recognize
+   Web-Store-installed ones at all, so pointing it at one is equivalent to
+   disabling everything. **Working alternative** (what `launch.mjs`
+   actually does): after CDP is up, open a `chrome://extensions` tab and
+   call `chrome.management.setEnabled(id, false)` directly from that page's
+   own JS context. That API is available there, unrestricted, without
+   toggling Developer Mode, for Web-Store-installed extensions.
+
+2. **MetaMask 13.35.1.0 selectors.** **Could not be fully verified live** --
+   see "Selector verification status" below. The onboarding screen's
+   testids (`onboarding-create-wallet`, `onboarding-import-wallet`) ARE
+   live-confirmed, since that screen was reachable. The unlock/connect/
+   confirm screens were not reachable (no initialised vault -- see
+   Onboarding), so their selectors in `metamask.mjs` are carried over from
+   MetaMask's long-stable public test-id conventions, not observed on this
+   build. **Confirm them the first time this skill runs against a real
+   unlocked account.**
+
+3. **The transient-popup race.** Designed defensively
+   (`metamask.mjs`'s `waitForTarget()` polls `GET /json/list` on a bounded
+   timeout, mirroring `browser-e2e.mjs`'s `waitFor()`), but not empirically
+   timed -- that requires a live connect/tx flow, which requires an
+   initialised vault (see Onboarding, again).
+
+4. **Is Arbitrum Sepolia already configured in this MetaMask instance?**
+   Measured **no**. `NetworkController.networkConfigurationsByChainId` on
+   this machine lists `0x1, 0x18c7, 0x2105, 0x279f, 0x38, 0x89, 0xa, 0xa4b1,
+   0xaa36a7, 0xe705, 0xe708` -- **no `0x66eee`** (Arbitrum Sepolia). Adding
+   it is an additional popup flow (MetaMask's "Add network" confirmation)
+   that this skill does not yet drive; plan for it before the first live
+   run against Sepolia.
+
+### Selector verification status -- read before trusting `metamask.mjs`
+
+Two independent, measured blockers prevented verifying `unlock()`,
+`connect()`, and `approveTx()`'s selectors against a real unlocked MetaMask
+instance on this machine:
+
+1. **The real debug profile's vault is not initialised.** `preflight.mjs`'s
+   check 3 does a live read of `chrome.storage.local` via the extension's
+   own service worker and found `KeyringController.vault` absent and
+   `AccountsController.internalAccounts.accounts` empty (`{}`). MetaMask's
+   own UI agrees: opening `home.html` redirects to `#/onboarding/welcome`,
+   never to an unlock screen. This directly contradicts the assumption this
+   skill was designed under ("MetaMask is already set up, only the
+   password is needed") -- a non-empty `Local Extension Settings/<id>`
+   directory (9MB+ on this machine) is **not** evidence of an initialised
+   vault; that directory holds all of `chrome.storage.local` for the
+   extension (locale, telemetry consent, feature flags, snap registries),
+   which is non-empty even for a never-onboarded install. See `preflight.mjs`
+   check 3's comment for the full reasoning -- this is exactly the kind of
+   false-positive proxy check that made smoke-test's Step 5 permanently
+   impossible, caught here before it could do the same.
+2. **A disposable substitute doesn't work either.** The obvious workaround
+   -- copy the installed extension's directory into a temp profile and load
+   it via `--load-extension` to get a throwaway wallet without touching the
+   real profile -- fails outright. Chrome's content-verification system
+   rejects it: `Content verify job failed for extension: <id> at path:
+   home.html and for reason:1` (hash mismatch), even with `_metadata/`
+   stripped from the copy. Web-Store-installed extensions cannot be
+   reloaded unpacked under their real ID on this Chrome build.
+
+Neither blocker is something this skill's code can work around -- both are
+Chrome/MetaMask platform behavior. The only path past them is a human
+completing Onboarding step 3 below (importing a seed by hand), after which
+a follow-up run should verify (and, if needed, correct) the unlock/connect/
+confirm selectors against the real unlocked instance before relying on them
+for anything unattended.
+
+## Chrome launch contract
+
+- `--user-data-dir=$HOME/.chrome-debug-profile` (override: `CDP_WALLET_PROFILE_DIR`)
+  -- the shared debug profile. Never a throwaway one for the real run: the
+  whole point is driving the same MetaMask install a human would use.
+- `--remote-debugging-port=<dynamically probed, from 9222>` -- never fixed,
+  so more than one Chrome (e.g. a preflight vault-check racing a real
+  automation run) doesn't collide.
+- No `--disable-extensions-except` (see measured unknown 1 above). Isolation
+  happens post-launch via `launch.mjs`'s `isolateExtensions()`.
+- Select the connector by **EIP-6963 `rdns === "io.metamask"`**, never by
+  button position -- the debug profile holds 5 other wallet-shaped
+  extensions (Braavos, Keplr, Xverse, UniSat, and the "Ready X" smart
+  wallet) plus an "Allow CORS" extension; leaving them enabled makes the
+  dapp's connector list order non-deterministic, and a CORS-bypass
+  extension makes any recording unrepresentative of what a real user sees.
+
+## Procedure
+
+```js
+import { launchChrome, findFreePort, waitForCdpReady, isolateExtensions, restoreExtensions, killChromeGroup, METAMASK_EXTENSION_ID } from "./launch.mjs";
+import { unlock, connect, approveTx } from "./metamask.mjs";
+
+const port = await findFreePort(9222);
+const chrome = launchChrome({ port, userDataDir: `${process.env.HOME}/.chrome-debug-profile` });
+await waitForCdpReady(port);
+const { disabledIds } = await isolateExtensions(port, METAMASK_EXTENSION_ID, chrome.pid);
+
+try {
+  const password = /* read via `security find-generic-password -s stylus-demo-metamask -w`, never echoed/logged */;
+  await unlock({ port, extensionId: METAMASK_EXTENSION_ID, password });
+
+  // Navigate a separate CDP target to your dapp, attach a CDP session to it
+  // (`dappCdp` below), THEN:
+  const { accounts } = await connect({ port, extensionId: METAMASK_EXTENSION_ID, dappCdp });
+
+  // Trigger the dapp's send/write action on dappCdp, then:
+  await approveTx({ port, extensionId: METAMASK_EXTENSION_ID });
+} finally {
+  await restoreExtensions(port, disabledIds, chrome.pid); // always, regardless of outcome
+  await killChromeGroup(chrome.pid);
+}
+```
+
+`node launch.mjs teardown` is the escape hatch if a run crashes mid-flight:
+it restores any extensions the crashed run disabled (using the same
+registry the run itself wrote to synchronously) and kills any leaked Chrome
+process groups it finds.
+
+## Secret handling
+
+```bash
+security find-generic-password -s stylus-demo-metamask -w
+```
+
+The password must never be printed, echoed, logged, committed, or passed as
+a literal command-line argument (which would land in shell history and
+process listings). If you need to show it's set, print its length only.
+
+The wallet being automated must hold **testnet funds only**. `approveTx()`
+clicks Confirm; it does not read or understand what it's confirming.
+Isolation -- a single-purpose Chrome profile, a testnet-only account -- is
+the actual safety control, not this script's judgement.
+
+## Process hygiene
+
+Chrome's PID is recorded **synchronously at spawn**, before
+`waitForCdpReady` or anything else that can throw -- a Chrome orphan
+survived five hours undetected on 2026-07-21 because a PID was only ever
+recorded on the failure path. Because the CDP port is probed dynamically
+(not fixed, unlike smoke-test's devnode port), the record is an **array**
+(`.cdp-wallet-state.json`) with dead-PID pruning on every read, not a
+single record that a second concurrent launch could silently clobber.
+
+The same crash-safety applies to extension isolation, not just Chrome
+processes: `isolateExtensions()` persists the list of extensions it
+disabled into that same registry entry, synchronously, before returning --
+measured directly (2026-07-22) by isolating, then killing the process
+without calling `restoreExtensions()`, then confirming `node launch.mjs
+teardown` still found and re-enabled every disabled extension from the
+registry alone. Without this, a crash between isolate and a later
+`restoreExtensions()` call leaves the developer's other wallets disabled
+with no trace of why -- the same failure shape as the Chrome-PID orphan,
+just for extensions instead of processes.
+
+`node launch.mjs list` prints the current registry (after pruning dead
+PIDs). `node launch.mjs teardown` restores extensions for every live entry
+that has any recorded, then kills the Chrome process group, then clears the
+registry.
+
+## Onboarding
+
+This skill depends on machine-local state that does not exist in the repo.
+Run `node .claude/skills/cdp-with-wallet/preflight.mjs` first -- it checks
+every prerequisite below and SKIPs (never hard-fails) with the exact fix
+when one is missing, the same contract as smoke-test's Steps 9a/9b.
+
+| # | Prerequisite | Scriptable? |
+|---|---|---|
+| 1 | `$HOME/.chrome-debug-profile` exists | Yes -- `preflight.mjs` checks it |
+| 2 | MetaMask installed in that profile | Yes to check, **no** to fix -- see below |
+| 3 | MetaMask vault initialised | Yes to check (a live `chrome.storage.local` read, not a directory-size guess -- see "Selector verification status" above for why), **no** to fix -- see below |
+| 4 | Keychain item `stylus-demo-metamask` present | Yes -- existence check only, never reads the value |
+| 5 | Arbitrum Sepolia RPC reachable via `packages/stylus/.env`'s `RPC_URL_SEPOLIA` | Yes |
+
+**Steps 2 and 3 cannot be scripted, and should not be** -- installing a
+Chrome extension and importing a seed phrase are exactly the kind of action
+this skill should never automate silently.
+
+**Step 2 (install MetaMask):**
+1. Launch Chrome with the debug profile: `"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --user-data-dir="$HOME/.chrome-debug-profile"`
+2. Go to the MetaMask Chrome Web Store page and click "Add to Chrome".
+3. Close Chrome.
+
+**Step 3 (initialise the vault) -- read this before doing it:**
+1. Launch Chrome with the same profile and open the MetaMask extension.
+2. Choose **"I already have a wallet"** and import an **existing seed
+   phrase for a TESTNET-ONLY account** -- one that has never held, and will
+   never hold, mainnet funds. `approveTx()` signs whatever it's pointed at
+   without reading it; the only real safety boundary here is that the
+   account itself has nothing worth stealing.
+3. Set the vault password to the **same value** already stored in Keychain
+   under `stylus-demo-metamask` (see Step 4 below), so `unlock()` can use
+   it without a mismatch.
+4. Fund the account with a small amount of Arbitrum Sepolia ETH from a
+   faucet (see `readme.md`'s "Arbitrum Testnet Faucets" section).
+
+**Step 4 (Keychain entry):**
+```bash
+security add-generic-password -s stylus-demo-metamask -a "$USER" -w
+```
+This prompts for the password interactively -- it is never echoed and never
+touches shell history. Do **not** pass `-w <password>` as a literal
+argument on the command line.
+
+**Step 5 (Sepolia RPC):** copy `packages/stylus/.env.example` to
+`packages/stylus/.env` if it doesn't exist, and fill in `RPC_URL_SEPOLIA` in
+the `## sepolia` block (a public endpoint such as
+`https://sepolia-rollup.arbitrum.io/rpc` works).
+
+Every check above was verified in **both** directions where a live present
+case exists: `preflight.mjs`'s output for the induced-absent case (a
+non-existent profile dir, a non-existent Keychain service name, a
+non-existent env file) and for the real present case (this machine's
+existing profile, extension, Keychain entry) are both in this repo's PR
+description / commit evidence. Check 3 (vault) could only be verified in
+the absent direction on this machine, since no present case exists here --
+see "Selector verification status" above.

--- a/.claude/skills/cdp-with-wallet/launch.mjs
+++ b/.claude/skills/cdp-with-wallet/launch.mjs
@@ -187,7 +187,23 @@ export async function waitForCdpReady(port, timeoutMs = 15000) {
 // pass --disable-extensions-except -- see the file header for why that flag
 // doesn't do what it looks like it does. Single-wallet isolation happens
 // AFTER launch via isolateExtensions(), once CDP is up.
-export function launchChrome({ port, userDataDir, headless = false }) {
+//
+// Defaults to headless -- MEASURED (2026-07-22), not assumed: `--headless=new`
+// (Chrome's newer headless mode, unlike the old one) runs extensions, which
+// is exactly why MetaMask is drivable at all without a visible window. Proof
+// is this skill's own preflight.mjs: its vault/password checks read
+// chrome.storage.local out of MetaMask's service worker, and drove a real
+// unlock()/connect()/wallet_addEthereumChain/eth_sendTransaction chain to a
+// mined Arbitrum Sepolia transaction, entirely with headless: true. A
+// visible window stealing focus for routine automation is a real cost, not
+// a neutral default -- so callers that just want automation get the
+// non-disruptive behavior without needing to know this flag exists.
+//
+// The one case that MUST pass headless: false explicitly: screen recording.
+// macOS `screencapture -v` cannot capture a headless window's contents (no
+// window to capture) -- if you're building the demo-video workflow (PR 2),
+// start here, or you will lose time to a black recording.
+export function launchChrome({ port, userDataDir, headless = true }) {
   const bin = findChromeBinary();
   const args = [
     `--remote-debugging-port=${port}`,

--- a/.claude/skills/cdp-with-wallet/launch.mjs
+++ b/.claude/skills/cdp-with-wallet/launch.mjs
@@ -199,10 +199,13 @@ export async function waitForCdpReady(port, timeoutMs = 15000) {
 // a neutral default -- so callers that just want automation get the
 // non-disruptive behavior without needing to know this flag exists.
 //
-// The one case that MUST pass headless: false explicitly: screen recording.
-// macOS `screencapture -v` cannot capture a headless window's contents (no
-// window to capture) -- if you're building the demo-video workflow (PR 2),
-// start here, or you will lose time to a black recording.
+// Recording the browser for a demo video does NOT require headless: false.
+// The initial demo-video design (PR 2) assumed macOS `screencapture -v` --
+// which does need a real, visible window -- but that path hit a real macOS
+// Screen Recording TCC permission gate mid-build. It was replaced with CDP's
+// own Page.startScreencast, which captures frames from inside Chrome
+// (works headless, needs no OS permission, and works in CI). See
+// .claude/skills/demo-video/SKILL.md for the frame-timing details.
 export function launchChrome({ port, userDataDir, headless = true }) {
   const bin = findChromeBinary();
   const args = [
@@ -272,6 +275,16 @@ export class CDP {
       this.pending.set(id, { resolve, reject });
       this.ws.send(JSON.stringify({ id, method, params }));
     });
+  }
+
+  // Persistent listener for events that fire repeatedly (e.g.
+  // Page.screencastFrame) -- unlike once(), the handler is never
+  // auto-removed. Returns an unsubscribe function.
+  on(method, handler) {
+    if (!this.eventListeners.has(method)) this.eventListeners.set(method, new Set());
+    const set = this.eventListeners.get(method);
+    set.add(handler);
+    return () => set.delete(handler);
   }
 
   once(method, timeoutMs, description = method) {

--- a/.claude/skills/cdp-with-wallet/launch.mjs
+++ b/.claude/skills/cdp-with-wallet/launch.mjs
@@ -1,0 +1,419 @@
+#!/usr/bin/env node
+// .claude/skills/cdp-with-wallet/launch.mjs
+//
+// Chrome launcher for the cdp-with-wallet skill -- profile handling,
+// dynamic-port CDP, single-wallet extension isolation, and PID process
+// hygiene. Raw Chrome DevTools Protocol over WebSocket, zero npm
+// dependencies, matching the in-repo precedent
+// .claude/skills/smoke-test/browser-e2e.mjs (same CDP client shape, same
+// findFreePort/waitForCdpReady idiom).
+//
+// MEASURED, not assumed (2026-07-22): --disable-extensions-except does NOT
+// selectively keep an installed (Web-Store) extension enabled in this Chrome
+// build (150.x). Tried both an installed-extension directory path and a bare
+// extension ID -- both disabled EVERY extension, including the one named,
+// confirmed via chrome.developerPrivate.getExtensionsInfo() showing an empty
+// list either way. That flag's allow-listing mechanism only recognizes
+// extensions loaded via --load-extension (unpacked/dev-mode); it does not
+// match extensions installed from the Web Store, so passing it a path/ID for
+// one is equivalent to just disabling everything. The verified working
+// alternative below is what SKILL.md's isolation contract actually relies
+// on: after CDP is up, open a chrome://extensions tab and call
+// chrome.management.setEnabled(id, false) directly -- that API IS available,
+// unrestricted, from a chrome://extensions page's own JS context, and does
+// not require Developer Mode to be toggled on for Web-Store-installed
+// (non-unpacked) extensions.
+//
+// CLI usage (process hygiene escape hatch, mirrors smoke-test's teardown.sh):
+//   node launch.mjs list      -- print the PID registry (after pruning dead PIDs)
+//   node launch.mjs teardown  -- kill every live Chrome in the registry, clear it
+//
+// Library usage (imported by preflight.mjs and metamask.mjs):
+//   import { launchChrome, findFreePort, waitForCdpReady, CDP,
+//            killChromeGroup, isolateExtensions, restoreExtensions } from "./launch.mjs"
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export class EnvironmentError extends Error {}
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+export const METAMASK_EXTENSION_ID = "nkbihfbeogaeaoehlefnkodbefgpgknn";
+
+// ---------------------------------------------------------------------------
+// PID registry -- array with dead-PID pruning, not a single record.
+//
+// The smoke-test skill's state.mjs (the in-repo precedent for "durable record
+// of a launched process") stores ONE PID per key, which is safe there
+// because Step 7's Chrome always binds a fixed, freshly-probed port for the
+// life of that one script. This skill's Chrome port is ALSO dynamically
+// probed, but unlike smoke-test, cdp-with-wallet is meant to be invoked
+// repeatedly and can legitimately have more than one Chrome instance
+// in flight (e.g. a preflight vault-check launch racing a real automation
+// launch) -- a single-record store would silently overwrite an earlier
+// still-alive entry and lose track of it. That is precisely how the Chrome
+// orphan on 2026-07-21 survived five hours undetected: a PID was only ever
+// recorded on the FAILURE path, one at a time, so a second concurrent
+// success/failure clobbered the first record entirely. This registry is an
+// array, and every entry is written synchronously at spawn time --
+// before waitForCdpReady, before anything that can throw -- so a crash
+// between spawn and readiness still leaves a recoverable trace.
+// ---------------------------------------------------------------------------
+
+const REGISTRY_PATH = path.join(path.dirname(fileURLToPath(import.meta.url)), ".cdp-wallet-state.json");
+
+function readRegistry() {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(REGISTRY_PATH, "utf8"));
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeRegistry(entries) {
+  fs.writeFileSync(REGISTRY_PATH, JSON.stringify(entries, null, 2) + "\n");
+}
+
+function isPidAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Drops entries whose PID is no longer running. Called on every read/write
+// so the registry never accumulates stale rows from processes that were
+// killed by some other means (e.g. `kill` by hand, a reboot).
+function pruneDead(entries) {
+  return entries.filter(e => isPidAlive(e.pid));
+}
+
+// Synchronous append -- called immediately after spawn(), before any await,
+// per the process-hygiene invariant above.
+function recordSpawn(entry) {
+  const entries = pruneDead(readRegistry());
+  entries.push(entry);
+  writeRegistry(entries);
+}
+
+function removeEntry(pid) {
+  writeRegistry(pruneDead(readRegistry()).filter(e => e.pid !== pid));
+}
+
+// Same synchronous-write discipline as recordSpawn(), for the OTHER piece of
+// state that must survive a crash: which extensions this run disabled.
+// MEASURED (2026-07-22): running isolateExtensions() twice without an
+// intervening restoreExtensions() silently disables zero NEW extensions on
+// the second run, because its filter only targets currently-ENABLED,
+// non-MetaMask extensions -- ones a prior crashed run already disabled are
+// invisible to it, so they can never come back via that run's own return
+// value. Without this record, a crash between isolate and restore leaves
+// the developer's other wallets/extensions disabled with no trace of why --
+// the exact same failure shape as the Chrome-PID orphan this registry
+// already exists to prevent, just for extensions instead of processes.
+function recordIsolation(pid, disabledExtensionIds) {
+  const entries = pruneDead(readRegistry());
+  const entry = entries.find(e => e.pid === pid);
+  if (entry) entry.disabledExtensionIds = disabledExtensionIds;
+  writeRegistry(entries);
+}
+
+export function listRegistry() {
+  const live = pruneDead(readRegistry());
+  writeRegistry(live); // persist the pruning itself, not just the read
+  return live;
+}
+
+// ---------------------------------------------------------------------------
+// Chrome discovery + launch
+// ---------------------------------------------------------------------------
+
+export function findChromeBinary() {
+  if (process.env.CHROME_PATH && fs.existsSync(process.env.CHROME_PATH)) {
+    return process.env.CHROME_PATH;
+  }
+  const candidates = [
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/Applications/Chromium.app/Contents/MacOS/Chromium",
+    "/usr/bin/google-chrome",
+    "/usr/bin/google-chrome-stable",
+    "/usr/bin/chromium",
+    "/usr/bin/chromium-browser",
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  throw new EnvironmentError(`No Chrome/Chromium binary found (checked: ${candidates.join(", ")}; override with CHROME_PATH)`);
+}
+
+export async function findFreePort(startPort, attempts = 20) {
+  const net = await import("node:net");
+  for (let offset = 0; offset < attempts; offset++) {
+    const candidate = startPort + offset;
+    const free = await new Promise(resolve => {
+      const server = net.createServer();
+      server.once("error", () => resolve(false));
+      server.listen(candidate, "127.0.0.1", () => server.close(() => resolve(true)));
+    });
+    if (free) return candidate;
+  }
+  throw new EnvironmentError(`No free debugging port found in range ${startPort}-${startPort + attempts - 1}`);
+}
+
+export async function waitForCdpReady(port, timeoutMs = 15000) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/json/version`);
+      if (res.ok) return res.json();
+    } catch (err) {
+      lastError = err;
+    }
+    await sleep(200);
+  }
+  throw new EnvironmentError(`Chrome's CDP endpoint on port ${port} never became reachable within ${timeoutMs}ms (last error: ${lastError?.message})`);
+}
+
+// Launches Chrome against `userDataDir` (the real debug profile, or a
+// temp/override one for testing) with CDP on `port`. Deliberately does NOT
+// pass --disable-extensions-except -- see the file header for why that flag
+// doesn't do what it looks like it does. Single-wallet isolation happens
+// AFTER launch via isolateExtensions(), once CDP is up.
+export function launchChrome({ port, userDataDir, headless = false }) {
+  const bin = findChromeBinary();
+  const args = [
+    `--remote-debugging-port=${port}`,
+    `--user-data-dir=${userDataDir}`,
+    "--no-first-run",
+    "--no-default-browser-check",
+    // Recent Chrome 403s a same-machine, non-browser WebSocket client on the
+    // CDP upgrade unless the Host/Origin is explicitly allowed.
+    "--remote-allow-origins=*",
+  ];
+  if (headless) args.push("--headless=new");
+
+  const child = spawn(bin, args, { detached: true, stdio: "ignore" });
+  child.unref();
+
+  // Record synchronously, before waitForCdpReady or anything else that can
+  // throw -- see the registry section above for why this ordering is the
+  // whole point.
+  recordSpawn({ pid: child.pid, port, userDataDir, startedAt: new Date().toISOString(), headless });
+
+  return { pid: child.pid, port, userDataDir };
+}
+
+export async function killChromeGroup(pid) {
+  try {
+    process.kill(-pid, "SIGTERM");
+  } catch {
+    /* already gone */
+  }
+  await sleep(1000);
+  try {
+    process.kill(-pid, "SIGKILL");
+  } catch {
+    /* already gone */
+  }
+  removeEntry(pid);
+}
+
+// ---------------------------------------------------------------------------
+// Minimal CDP client (JSON-RPC over the native WebSocket) -- same shape as
+// smoke-test/browser-e2e.mjs's CDP class.
+// ---------------------------------------------------------------------------
+
+export class CDP {
+  constructor(ws) {
+    this.ws = ws;
+    this.nextId = 1;
+    this.pending = new Map();
+    this.eventListeners = new Map();
+    ws.addEventListener("message", event => {
+      const msg = JSON.parse(event.data);
+      if (msg.id !== undefined && this.pending.has(msg.id)) {
+        const { resolve, reject } = this.pending.get(msg.id);
+        this.pending.delete(msg.id);
+        if (msg.error) reject(new Error(`CDP error (${msg.error.code}): ${msg.error.message}`));
+        else resolve(msg.result);
+      } else if (msg.method && this.eventListeners.has(msg.method)) {
+        for (const handler of this.eventListeners.get(msg.method)) handler(msg.params);
+      }
+    });
+  }
+
+  send(method, params = {}) {
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.ws.send(JSON.stringify({ id, method, params }));
+    });
+  }
+
+  once(method, timeoutMs, description = method) {
+    return new Promise((resolve, reject) => {
+      if (!this.eventListeners.has(method)) this.eventListeners.set(method, new Set());
+      const set = this.eventListeners.get(method);
+      const timer = setTimeout(() => {
+        set.delete(handler);
+        reject(new EnvironmentError(`Timed out after ${timeoutMs}ms waiting for CDP event: ${description}`));
+      }, timeoutMs);
+      const handler = params => {
+        clearTimeout(timer);
+        set.delete(handler);
+        resolve(params);
+      };
+      set.add(handler);
+    });
+  }
+}
+
+export async function evaluate(cdp, expression) {
+  const result = await cdp.send("Runtime.evaluate", { expression, returnByValue: true, awaitPromise: true });
+  if (result.exceptionDetails) {
+    const desc = result.exceptionDetails.exception?.description || JSON.stringify(result.exceptionDetails);
+    throw new Error(`Runtime.evaluate threw: ${desc}`);
+  }
+  return result.result?.value;
+}
+
+async function openTab(port, url) {
+  const res = await fetch(`http://127.0.0.1:${port}/json/new?${encodeURIComponent(url)}`, { method: "PUT" });
+  if (!res.ok) throw new EnvironmentError(`PUT /json/new failed with HTTP ${res.status}`);
+  return res.json();
+}
+
+async function attachCdp(target) {
+  const ws = new WebSocket(target.webSocketDebuggerUrl);
+  await new Promise((resolve, reject) => {
+    ws.addEventListener("open", () => resolve(), { once: true });
+    ws.addEventListener("error", err => reject(new EnvironmentError(`WebSocket connect failed: ${err.message}`)), { once: true });
+  });
+  const cdp = new CDP(ws);
+  await cdp.send("Runtime.enable");
+  return { cdp, ws };
+}
+
+// ---------------------------------------------------------------------------
+// Single-wallet extension isolation
+//
+// The debug profile also holds four other wallets (Braavos, Keplr, Xverse,
+// and the "Ready X" smart wallet) plus an "Allow CORS" extension. All of the
+// Ethereum-announcing ones broadcast via EIP-6963, so leaving them enabled
+// makes the dapp's connector list non-deterministic; the CORS extension
+// would make any recording unrepresentative of what a real user sees. See
+// the file header for why --disable-extensions-except can't do this.
+// ---------------------------------------------------------------------------
+
+// Disables every extension except `keepId` via chrome.management, returns
+// the list of extension IDs it disabled (for restoreExtensions() to reverse)
+// plus the ID of the helper tab it opened, so the caller can close it. `pid`
+// is the Chrome PID from launchChrome() -- passing it lets this function
+// persist the disabled-list into that PID's registry entry synchronously
+// (see recordIsolation() above), so a crash before restoreExtensions() runs
+// still leaves a recoverable trace, the same invariant applied to PIDs
+// themselves.
+export async function isolateExtensions(port, keepId = METAMASK_EXTENSION_ID, pid = null) {
+  const tab = await openTab(port, "chrome://extensions/");
+  const { cdp, ws } = await attachCdp(tab);
+  try {
+    const disabledIds = await evaluate(
+      cdp,
+      `(async () => {
+        const list = await new Promise((resolve) => chrome.management.getAll(resolve));
+        const toDisable = list.filter(e => e.id !== ${JSON.stringify(keepId)} && e.type === "extension" && e.enabled);
+        const disabled = [];
+        for (const e of toDisable) {
+          await new Promise((resolve, reject) => {
+            chrome.management.setEnabled(e.id, false, () => {
+              if (chrome.runtime.lastError) reject(new Error(chrome.runtime.lastError.message));
+              else resolve();
+            });
+          });
+          disabled.push(e.id);
+        }
+        return disabled;
+      })()`,
+    );
+    if (pid !== null) recordIsolation(pid, disabledIds);
+    return { disabledIds, tabId: tab.id };
+  } finally {
+    ws.close();
+    await fetch(`http://127.0.0.1:${port}/json/close/${tab.id}`).catch(() => {});
+  }
+}
+
+// Re-enables every extension isolateExtensions() disabled. This MUST run on
+// every exit path (pass, fail, crash) -- the debug profile is the developer's
+// real, persistent Chrome profile, not a throwaway one, so leaving other
+// wallets disabled after a run would silently modify their environment.
+// `pid`, if passed, clears the isolation record on success so a later
+// teardown doesn't try to restore an already-restored list.
+export async function restoreExtensions(port, disabledIds, pid = null) {
+  if (!disabledIds?.length) return;
+  const tab = await openTab(port, "chrome://extensions/");
+  const { cdp, ws } = await attachCdp(tab);
+  try {
+    await evaluate(
+      cdp,
+      `(async () => {
+        for (const id of ${JSON.stringify(disabledIds)}) {
+          await new Promise((resolve) => chrome.management.setEnabled(id, true, () => resolve()));
+        }
+      })()`,
+    );
+    if (pid !== null) recordIsolation(pid, []);
+  } finally {
+    ws.close();
+    await fetch(`http://127.0.0.1:${port}/json/close/${tab.id}`).catch(() => {});
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI (process-hygiene escape hatch)
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const [, , cmd] = process.argv;
+  switch (cmd) {
+    case "list": {
+      const live = listRegistry();
+      console.log(JSON.stringify(live, null, 2));
+      break;
+    }
+    case "teardown": {
+      const live = listRegistry();
+      if (!live.length) {
+        console.log("No live Chrome instances in the registry.");
+        break;
+      }
+      for (const entry of live) {
+        if (entry.disabledExtensionIds?.length) {
+          console.log(`Restoring ${entry.disabledExtensionIds.length} extension(s) disabled by PID ${entry.pid} before killing it`);
+          await restoreExtensions(entry.port, entry.disabledExtensionIds, entry.pid).catch(err =>
+            console.error(`  could not restore extensions (Chrome may already be unresponsive): ${err.message}`),
+          );
+        }
+        console.log(`Killing PID ${entry.pid} (port ${entry.port}, profile ${entry.userDataDir})`);
+        await killChromeGroup(entry.pid);
+      }
+      console.log("Done.");
+      break;
+    }
+    default:
+      console.error("usage: launch.mjs <list|teardown>");
+      process.exit(1);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/.claude/skills/cdp-with-wallet/metamask.mjs
+++ b/.claude/skills/cdp-with-wallet/metamask.mjs
@@ -45,6 +45,15 @@
 
 import { CDP, evaluate, EnvironmentError } from "./launch.mjs";
 
+// Distinct from EnvironmentError: this means CDP/Chrome/MetaMask all worked
+// correctly and the password itself was rejected -- a Keychain/vault
+// mismatch, not a script bug. preflight.mjs's Keychain check matches on
+// this class specifically (not on the error TEXT, which is locale-specific
+// -- MEASURED: this profile's MetaMask renders in Vietnamese, "Mật khẩu
+// không chính xác. Vui lòng thử lại.") so the check works regardless of the
+// browser's UI language.
+export class IncorrectPasswordError extends Error {}
+
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 // ---------------------------------------------------------------------------
@@ -85,6 +94,30 @@ async function attach(target) {
 // Vietnamese, e.g. "Tạo ví mới" / "Tôi đã có ví" on the onboarding screen, so
 // any English text match would silently never fire there) over role/text
 // matching, which is kept only as a last-resort fallback.
+// MEASURED (2026-07-22): MetaMask 13.35.1.0 runs under LavaMoat "scuttling",
+// which throws `Error: LavaMoat - property "HTMLInputElement" of globalThis
+// is inaccessible under scuttling mode` the moment page JS touches a global
+// constructor's prototype (the usual React-controlled-input trick of
+// grabbing the native value setter off HTMLInputElement.prototype to bypass
+// React's own setter). That rules out setting .value via JS entirely on
+// this extension. The working alternative: focus the element with a plain
+// instance method call (`el.focus()` -- not a global lookup, LavaMoat
+// allows it), then use CDP's own `Input.insertText`, which inserts text at
+// the browser level as if typed, never touching page-global objects at all.
+async function fillInput(cdp, selector, text) {
+  const focused = await evaluate(
+    cdp,
+    `(() => {
+      const el = document.querySelector(${JSON.stringify(selector)});
+      if (!el) return "NOT_FOUND";
+      el.focus();
+      return document.activeElement === el ? "FOCUSED" : "FOCUS_FAILED";
+    })()`,
+  );
+  if (focused !== "FOCUSED") throw new EnvironmentError(`Could not focus ${selector} (${focused})`);
+  await cdp.send("Input.insertText", { text });
+}
+
 async function clickFirstMatch(cdp, selectors) {
   return evaluate(
     cdp,
@@ -116,7 +149,18 @@ export async function unlock({ port, extensionId, password }) {
   const tab = await res.json();
   const { cdp, ws } = await attach(tab);
   try {
-    await sleep(1500); // let the extension's router settle before reading document.URL
+    // MEASURED (2026-07-22): a fixed sleep before checking lock state is a
+    // real bug, not just slow -- observed directly: at 500ms-1500ms after
+    // navigation, home.html has rendered NOTHING yet (zero [data-testid]
+    // elements at all, on a headless launch), so a same-moment "is the
+    // unlock screen present" check reads false and this function concluded
+    // "already unlocked" when the app simply hadn't painted anything yet.
+    // That is a false negative that would have silently skipped testing the
+    // password entirely -- exactly the failure shape this skill's own
+    // preflight check 4 exists to catch elsewhere (a proxy that looks like
+    // it proves something but doesn't). Poll for the app to render ANYTHING
+    // recognizable first, then decide.
+    await sleepUntil(async () => (await evaluate(cdp, `document.querySelectorAll('[data-testid]').length`)) > 0, 8000);
     const url = await evaluate(cdp, "document.URL");
 
     if (url.includes("#/onboarding")) {
@@ -126,34 +170,47 @@ export async function unlock({ port, extensionId, password }) {
       );
     }
 
-    const isLocked = await evaluate(cdp, `!!document.querySelector('[data-testid="unlock-password"]') || !!document.querySelector('input[type="password"]')`);
+    const isLocked = await evaluate(cdp, `!!document.querySelector('[data-testid="unlock-password"]')`);
     if (!isLocked) {
       return { alreadyUnlocked: true };
     }
 
-    await evaluate(
-      cdp,
-      `(() => {
-        const input = document.querySelector('[data-testid="unlock-password"]') || document.querySelector('input[type="password"]');
-        const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set;
-        setter.call(input, ${JSON.stringify(password)});
-        input.dispatchEvent(new Event("input", { bubbles: true }));
-      })()`,
-    );
+    await fillInput(cdp, '[data-testid="unlock-password"]', password);
     const clicked = await clickFirstMatch(cdp, ['[data-testid="unlock-submit"]', 'button[type="submit"]']);
     if (!clicked) throw new EnvironmentError("Could not find an unlock-submit button");
 
-    await sleepUntil(async () => !(await evaluate(cdp, `!!document.querySelector('input[type="password"]')`)), 10000);
+    // Race the two outcomes MetaMask actually has for a submitted password:
+    // the password input disappearing (success) or its own error banner
+    // appearing (rejected) -- LIVE-VERIFIED selector for the latter,
+    // `[data-testid="unlock-page-help-text"]`, found while diagnosing a real
+    // Keychain/vault password mismatch on 2026-07-22.
+    const outcome = await sleepUntil(async () => {
+      const stillLocked = await evaluate(cdp, `!!document.querySelector('input[type="password"]')`);
+      if (!stillLocked) return "unlocked";
+      const errorText = await evaluate(cdp, `document.querySelector('[data-testid="unlock-page-help-text"]')?.textContent?.trim() || ""`);
+      if (errorText) return "rejected";
+      return null;
+    }, 10000);
+    if (outcome === "rejected") {
+      throw new IncorrectPasswordError(
+        "MetaMask rejected the password (the vault's own error banner appeared) -- the value stored in " +
+          "the Keychain does not match this vault's actual password.",
+      );
+    }
     return { alreadyUnlocked: false };
   } finally {
     ws.close();
   }
 }
 
+// Returns whatever truthy value conditionFn() produces (not just a
+// boolean), so callers racing multiple distinct outcomes (e.g. "unlocked"
+// vs "rejected" above) can tell which one actually happened.
 async function sleepUntil(conditionFn, timeoutMs, intervalMs = 300) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (await conditionFn()) return;
+    const result = await conditionFn();
+    if (result) return result;
     await sleep(intervalMs);
   }
   throw new EnvironmentError(`Condition not met within ${timeoutMs}ms`);

--- a/.claude/skills/cdp-with-wallet/metamask.mjs
+++ b/.claude/skills/cdp-with-wallet/metamask.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+// .claude/skills/cdp-with-wallet/metamask.mjs
+//
+// MetaMask primitives: unlock / connect / approveTx / waitForTarget. This is
+// the reusable part of the skill -- callers bring their own dapp page (a CDP
+// target already navigated to the app under test) and their own Chrome
+// launch (see launch.mjs); this file only knows how to drive MetaMask's own
+// extension pages via raw CDP, following the technique demonstrated in
+// Brove's packages/nextjs/e2e/helpers/braavos.ts: enumerate targets from
+// GET /json, find the extension page by URL prefix, attach a WebSocket
+// directly to it. Braavos itself is a different extension with different
+// selectors -- only the TECHNIQUE carries over, not any selector or path.
+//
+// *** SELECTOR VERIFICATION STATUS (2026-07-22) ***
+// The selectors below could NOT be verified against a live unlocked
+// instance. Two independent blockers, both measured on this machine:
+//   1. The real debug profile's MetaMask vault is not initialised -- no
+//      seed has been imported (see preflight.mjs check 3 / SKILL.md). Its
+//      home.html redirects to #/onboarding/welcome, never to an unlock
+//      screen, and chrome.storage.local's AccountsController has zero
+//      accounts. This directly contradicts the assumption the skill was
+//      designed under ("MetaMask is already set up, only the password is
+//      needed") -- run preflight.mjs (its check 3 does this same live
+//      check) before trusting these selectors against your profile.
+//   2. A disposable substitute (copying the installed extension into a temp
+//      profile via --load-extension, to discover selectors without touching
+//      the real profile) does not work either: Chrome's content-verification
+//      system rejects it outright --
+//      "Content verify job failed for extension: <id> at path: home.html and
+//      for reason:1" (hash mismatch) -- even with the installed copy's
+//      _metadata/ stripped. Web-Store-installed extensions cannot be
+//      reloaded unpacked under their real ID on this Chrome build.
+// The onboarding-screen testids below (onboarding-create-wallet,
+// onboarding-import-wallet) ARE live-verified -- that screen was reachable.
+// unlock-password / unlock-submit and the connect/confirm-screen selectors
+// are carried over from MetaMask's long-stable public test-id conventions,
+// NOT observed live on 13.35.1.0. Confirm them (or fix them) the first time
+// this skill is run against a real unlocked account, before relying on it.
+//
+// Primitives:
+//   unlock({ port, extensionId, password })
+//   connect({ port, extensionId, dappCdp })
+//   approveTx({ port, extensionId })
+//   waitForTarget(port, predicate, opts)
+
+import { CDP, evaluate, EnvironmentError } from "./launch.mjs";
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+// ---------------------------------------------------------------------------
+// Target discovery -- the "transient popup race" guard.
+//
+// MEASURED RISK (not yet empirically timed -- see verification-status header
+// above): MetaMask's connect/confirm popups are ordinary CDP page targets
+// that only exist while the notification window is open. A caller that reads
+// GET /json once, right after triggering a dapp request, can race ahead of
+// Chrome actually creating that window and see it as absent. This mirrors
+// browser-e2e.mjs's waitFor() -- poll a condition with a bounded timeout
+// instead of a single check.
+// ---------------------------------------------------------------------------
+export async function waitForTarget(port, predicate, { timeoutMs = 15000, intervalMs = 300, description = "target" } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const list = await fetch(`http://127.0.0.1:${port}/json/list`).then(r => r.json());
+    const target = list.find(predicate);
+    if (target) return target;
+    await sleep(intervalMs);
+  }
+  throw new EnvironmentError(`Timed out after ${timeoutMs}ms waiting for: ${description}`);
+}
+
+async function attach(target) {
+  const ws = new WebSocket(target.webSocketDebuggerUrl);
+  await new Promise((resolve, reject) => {
+    ws.addEventListener("open", () => resolve(), { once: true });
+    ws.addEventListener("error", err => reject(new EnvironmentError(`WebSocket connect failed: ${err.message}`)), { once: true });
+  });
+  const cdp = new CDP(ws);
+  await cdp.send("Runtime.enable");
+  return { cdp, ws };
+}
+
+// Tries a list of selectors in order, clicking the first one found. Prefers
+// data-testid (stable across locale -- this profile's MetaMask renders in
+// Vietnamese, e.g. "Tạo ví mới" / "Tôi đã có ví" on the onboarding screen, so
+// any English text match would silently never fire there) over role/text
+// matching, which is kept only as a last-resort fallback.
+async function clickFirstMatch(cdp, selectors) {
+  return evaluate(
+    cdp,
+    `(() => {
+      const selectors = ${JSON.stringify(selectors)};
+      for (const sel of selectors) {
+        const el = document.querySelector(sel);
+        if (el && !el.disabled) {
+          el.click();
+          return sel;
+        }
+      }
+      return null;
+    })()`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// unlock(password) -- open home.html; if the unlock screen is present, fill
+// and submit. If MetaMask is already unlocked (or mid-onboarding, which is a
+// distinct, non-scriptable state -- see preflight.mjs check 3), this is a
+// no-op / explicit error rather than a silent false PASS.
+// ---------------------------------------------------------------------------
+export async function unlock({ port, extensionId, password }) {
+  const res = await fetch(`http://127.0.0.1:${port}/json/new?${encodeURIComponent(`chrome-extension://${extensionId}/home.html`)}`, {
+    method: "PUT",
+  });
+  if (!res.ok) throw new EnvironmentError(`Could not open MetaMask home.html: HTTP ${res.status}`);
+  const tab = await res.json();
+  const { cdp, ws } = await attach(tab);
+  try {
+    await sleep(1500); // let the extension's router settle before reading document.URL
+    const url = await evaluate(cdp, "document.URL");
+
+    if (url.includes("#/onboarding")) {
+      throw new EnvironmentError(
+        "MetaMask is mid-onboarding (no vault yet), not locked -- this is not something unlock() can fix. " +
+          "See SKILL.md Onboarding step 3: a seed must be imported by hand first.",
+      );
+    }
+
+    const isLocked = await evaluate(cdp, `!!document.querySelector('[data-testid="unlock-password"]') || !!document.querySelector('input[type="password"]')`);
+    if (!isLocked) {
+      return { alreadyUnlocked: true };
+    }
+
+    await evaluate(
+      cdp,
+      `(() => {
+        const input = document.querySelector('[data-testid="unlock-password"]') || document.querySelector('input[type="password"]');
+        const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set;
+        setter.call(input, ${JSON.stringify(password)});
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+      })()`,
+    );
+    const clicked = await clickFirstMatch(cdp, ['[data-testid="unlock-submit"]', 'button[type="submit"]']);
+    if (!clicked) throw new EnvironmentError("Could not find an unlock-submit button");
+
+    await sleepUntil(async () => !(await evaluate(cdp, `!!document.querySelector('input[type="password"]')`)), 10000);
+    return { alreadyUnlocked: false };
+  } finally {
+    ws.close();
+  }
+}
+
+async function sleepUntil(conditionFn, timeoutMs, intervalMs = 300) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await conditionFn()) return;
+    await sleep(intervalMs);
+  }
+  throw new EnvironmentError(`Condition not met within ${timeoutMs}ms`);
+}
+
+// ---------------------------------------------------------------------------
+// connect() -- select the connector by EIP-6963 rdns === "io.metamask",
+// NEVER by button position (a dapp's connector list order depends on
+// extension load order / announce timing, which this skill does not
+// control). `dappCdp` is an already-attached CDP session on the dapp's own
+// page (the caller navigates there first); this function only injects the
+// EIP-6963 discovery + eth_requestAccounts call into THAT page, then
+// switches to the resulting MetaMask popup to approve it.
+// ---------------------------------------------------------------------------
+export async function connect({ port, extensionId, dappCdp }) {
+  // Ask the page for every announced EIP-6963 provider, matched by rdns.
+  const requestPromise = evaluate(
+    dappCdp,
+    `(() => {
+      return new Promise((resolve, reject) => {
+        const providers = [];
+        function onAnnounce(event) { providers.push(event.detail); }
+        window.addEventListener("eip6963:announceProvider", onAnnounce);
+        window.dispatchEvent(new Event("eip6963:requestProvider"));
+        setTimeout(() => {
+          window.removeEventListener("eip6963:announceProvider", onAnnounce);
+          const match = providers.find(p => p.info?.rdns === "io.metamask");
+          if (!match) {
+            reject(new Error("No EIP-6963 provider announced rdns=io.metamask (providers seen: " + providers.map(p => p.info?.rdns).join(", ") + ")"));
+            return;
+          }
+          match.provider.request({ method: "eth_requestAccounts" }).then(resolve, reject);
+        }, 500);
+      });
+    })()`,
+  );
+
+  // eth_requestAccounts opens MetaMask's connect popup as a side effect --
+  // race against that popup appearing (see waitForTarget's header comment).
+  const popup = await waitForTarget(
+    port,
+    t => t.type === "page" && t.url.startsWith(`chrome-extension://${extensionId}/notification.html`),
+    { timeoutMs: 15000, description: "MetaMask connect popup (notification.html)" },
+  );
+  const { cdp: popupCdp, ws } = await attach(popup);
+  try {
+    // Modern MetaMask connect flows are 1-2 screens (permissions overview,
+    // then a final confirm) -- click whichever "proceed" button is present,
+    // repeating until the popup closes or eth_requestAccounts resolves.
+    const deadline = Date.now() + 15000;
+    while (Date.now() < deadline) {
+      const clicked = await clickFirstMatch(popupCdp, [
+        '[data-testid="confirm-btn"]',
+        '[data-testid="page-container-footer-next"]',
+        '[data-testid="connect-account-confirm"]',
+        'button[type="submit"]',
+      ]).catch(() => null); // popup may close mid-poll -- target gone is not a failure here
+      if (clicked) await sleep(700);
+      const stillOpen = await fetch(`http://127.0.0.1:${port}/json/list`)
+        .then(r => r.json())
+        .then(list => list.some(t => t.id === popup.id));
+      if (!stillOpen) break;
+      await sleep(300);
+    }
+  } finally {
+    ws.close();
+  }
+
+  const accounts = await requestPromise;
+  return { accounts };
+}
+
+// ---------------------------------------------------------------------------
+// approveTx() -- attach to the notification.html target and confirm. Same
+// transient-popup race as connect(); callers trigger the tx (e.g. clicking
+// a dapp's "Send" button) and then call this to drive the resulting
+// MetaMask confirmation to completion.
+// ---------------------------------------------------------------------------
+export async function approveTx({ port, extensionId, timeoutMs = 20000 }) {
+  const popup = await waitForTarget(
+    port,
+    t => t.type === "page" && t.url.startsWith(`chrome-extension://${extensionId}/notification.html`),
+    { timeoutMs, description: "MetaMask transaction confirmation popup (notification.html)" },
+  );
+  const { cdp, ws } = await attach(popup);
+  try {
+    const clicked = await clickFirstMatch(cdp, [
+      '[data-testid="confirm-footer-button"]',
+      '[data-testid="page-container-footer-next"]',
+      '[data-testid="confirm-btn"]',
+      'button[type="submit"]',
+    ]);
+    if (!clicked) throw new EnvironmentError("Could not find a confirm/approve button on the transaction popup");
+    return { clickedSelector: clicked };
+  } finally {
+    ws.close();
+  }
+}

--- a/.claude/skills/cdp-with-wallet/metamask.mjs
+++ b/.claude/skills/cdp-with-wallet/metamask.mjs
@@ -11,36 +11,41 @@
 // directly to it. Braavos itself is a different extension with different
 // selectors -- only the TECHNIQUE carries over, not any selector or path.
 //
-// *** SELECTOR VERIFICATION STATUS (2026-07-22) ***
-// The selectors below could NOT be verified against a live unlocked
-// instance. Two independent blockers, both measured on this machine:
-//   1. The real debug profile's MetaMask vault is not initialised -- no
-//      seed has been imported (see preflight.mjs check 3 / SKILL.md). Its
-//      home.html redirects to #/onboarding/welcome, never to an unlock
-//      screen, and chrome.storage.local's AccountsController has zero
-//      accounts. This directly contradicts the assumption the skill was
-//      designed under ("MetaMask is already set up, only the password is
-//      needed") -- run preflight.mjs (its check 3 does this same live
-//      check) before trusting these selectors against your profile.
-//   2. A disposable substitute (copying the installed extension into a temp
-//      profile via --load-extension, to discover selectors without touching
-//      the real profile) does not work either: Chrome's content-verification
-//      system rejects it outright --
-//      "Content verify job failed for extension: <id> at path: home.html and
-//      for reason:1" (hash mismatch) -- even with the installed copy's
-//      _metadata/ stripped. Web-Store-installed extensions cannot be
-//      reloaded unpacked under their real ID on this Chrome build.
-// The onboarding-screen testids below (onboarding-create-wallet,
-// onboarding-import-wallet) ARE live-verified -- that screen was reachable.
-// unlock-password / unlock-submit and the connect/confirm-screen selectors
-// are carried over from MetaMask's long-stable public test-id conventions,
-// NOT observed live on 13.35.1.0. Confirm them (or fix them) the first time
-// this skill is run against a real unlocked account, before relying on it.
+// *** SELECTOR VERIFICATION STATUS ***
+// LIVE-VERIFIED end to end on 2026-07-22, once the real profile's vault was
+// actually initialised (see SKILL.md Onboarding -- it was not, initially;
+// a non-empty extension-storage directory is not evidence of an
+// initialised vault, and this skill nearly shipped that false assumption).
+// The full chain was driven for real against Arbitrum Sepolia: unlock() ->
+// wallet_addEthereumChain (0x66eee, not preconfigured -- see SKILL.md
+// "Measured unknowns") -> connect() via EIP-6963 -> a real
+// eth_sendTransaction, mined and confirmed (status: 1) on-chain. Every
+// selector below is exactly what was clicked in that run, not a guess:
+//   - '[data-testid="unlock-password"]' / '[data-testid="unlock-submit"]'
+//     -- the unlock screen.
+//   - '[data-testid="unlock-page-help-text"]' -- the wrong-password error
+//     banner (locale-agnostic; this profile's MetaMask renders in
+//     Vietnamese, so text-matching would have been a trap of its own).
+//   - '[data-testid="confirm-btn"]' -- the connect-permissions screen's
+//     approve button (a single screen in this run, not the two some older
+//     MetaMask versions used).
+//   - '[data-testid="confirm-footer-button"]' -- approves BOTH a
+//     wallet_addEthereumChain confirmation and a transaction confirmation;
+//     MetaMask reuses the same confirmation-screen component for both, so
+//     approveTx() also happens to be the right primitive for approving an
+//     add-network request, without needing a separate function.
+// The remaining entries in each clickFirstMatch() fallback list below
+// (page-container-footer-next, connect-account-confirm, a bare
+// button[type="submit"]) were NEVER exercised in this run -- the
+// live-confirmed selector matched first every time. They stay as
+// defensive fallbacks for other MetaMask versions, but are NOT confirmed;
+// treat a run that falls through to one of them as a signal to
+// investigate, not as proof they work.
 //
 // Primitives:
 //   unlock({ port, extensionId, password })
 //   connect({ port, extensionId, dappCdp })
-//   approveTx({ port, extensionId })
+//   approveTx({ port, extensionId })       -- also approves add-network requests
 //   waitForTarget(port, predicate, opts)
 
 import { CDP, evaluate, EnvironmentError } from "./launch.mjs";
@@ -257,8 +262,11 @@ export async function connect({ port, extensionId, dappCdp }) {
   );
   const { cdp: popupCdp, ws } = await attach(popup);
   try {
-    // Modern MetaMask connect flows are 1-2 screens (permissions overview,
-    // then a final confirm) -- click whichever "proceed" button is present,
+    // LIVE-VERIFIED (2026-07-22): this build's connect flow is a single
+    // screen -- '[data-testid="confirm-btn"]' resolved eth_requestAccounts
+    // immediately, no second screen appeared. The loop below still handles
+    // a multi-screen flow defensively (older/other MetaMask builds have
+    // used one), clicking whichever "proceed" button is present and
     // repeating until the popup closes or eth_requestAccounts resolves.
     const deadline = Date.now() + 15000;
     while (Date.now() < deadline) {
@@ -285,9 +293,14 @@ export async function connect({ port, extensionId, dappCdp }) {
 
 // ---------------------------------------------------------------------------
 // approveTx() -- attach to the notification.html target and confirm. Same
-// transient-popup race as connect(); callers trigger the tx (e.g. clicking
-// a dapp's "Send" button) and then call this to drive the resulting
-// MetaMask confirmation to completion.
+// transient-popup race as connect() -- MEASURED directly (2026-07-22): the
+// first /json/list poll right after triggering eth_sendTransaction found no
+// notification.html target at all; it appeared roughly a second later.
+// Callers trigger the request (e.g. calling eth_sendTransaction, or a
+// dapp's "Send" button) and then call this to drive the resulting
+// MetaMask confirmation to completion. Also works, unmodified, for a
+// wallet_addEthereumChain confirmation -- MetaMask renders both through
+// the same confirmation-screen component and the same confirm-footer-button.
 // ---------------------------------------------------------------------------
 export async function approveTx({ port, extensionId, timeoutMs = 20000 }) {
   const popup = await waitForTarget(

--- a/.claude/skills/cdp-with-wallet/metamask.mjs
+++ b/.claude/skills/cdp-with-wallet/metamask.mjs
@@ -301,6 +301,18 @@ export async function connect({ port, extensionId, dappCdp }) {
 // MetaMask confirmation to completion. Also works, unmodified, for a
 // wallet_addEthereumChain confirmation -- MetaMask renders both through
 // the same confirmation-screen component and the same confirm-footer-button.
+//
+// MEASURED (2026-07-22, building demo-video/PR 2): a SECOND race, inside the
+// popup itself, not just around its existence. Attaching CDP the moment
+// `/json/list` reports the notification.html target existing is not the
+// same as that target having painted anything yet -- clickFirstMatch() ran
+// against a still-blank document and found no match, even though the exact
+// same '[data-testid="confirm-footer-button"]' selector was confirmed
+// present and clickable ~1.5s later via a manual repro. This is the same
+// failure shape unlock() already had to fix (a target existing is not the
+// same as it having rendered) -- applying the same fix here: poll for a
+// recognizable element before attempting to click, instead of one
+// immediate attempt.
 // ---------------------------------------------------------------------------
 export async function approveTx({ port, extensionId, timeoutMs = 20000 }) {
   const popup = await waitForTarget(
@@ -310,6 +322,7 @@ export async function approveTx({ port, extensionId, timeoutMs = 20000 }) {
   );
   const { cdp, ws } = await attach(popup);
   try {
+    await sleepUntil(async () => (await evaluate(cdp, `document.querySelectorAll('[data-testid]').length`)) > 0, 8000);
     const clicked = await clickFirstMatch(cdp, [
       '[data-testid="confirm-footer-button"]',
       '[data-testid="page-container-footer-next"]',

--- a/.claude/skills/cdp-with-wallet/preflight.mjs
+++ b/.claude/skills/cdp-with-wallet/preflight.mjs
@@ -1,0 +1,325 @@
+#!/usr/bin/env node
+// .claude/skills/cdp-with-wallet/preflight.mjs
+//
+// Onboarding gate for the cdp-with-wallet skill. Every prerequisite here
+// depends on MACHINE-LOCAL state that does not exist in the repo: a Chrome
+// profile with MetaMask installed and set up, a Keychain entry, and a
+// reachable Sepolia RPC. The machine this skill was designed on has all of
+// it; no other machine does automatically.
+//
+// Same contract as smoke-test's Steps 9a/9b: a missing prerequisite SKIPs
+// with the exact fix command, it never hard-fails/throws. This script only
+// reads state (filesystem stats, a Keychain existence check, one RPC call);
+// it never installs, imports, or writes anything.
+//
+// Usage:
+//   node .claude/skills/cdp-with-wallet/preflight.mjs
+//
+// Exit codes:
+//   0 - every prerequisite satisfied, skill is ready to run
+//   1 - one or more prerequisites are missing (see per-check SKIP lines above
+//       the summary for the exact fix). This is NOT a crash -- it is the
+//       expected result on a machine that hasn't been onboarded yet.
+//
+// Env var overrides (for testing the absent case WITHOUT touching the real
+// profile/Keychain/env file -- never delete or edit the real ones to test
+// this script):
+//   CDP_WALLET_PROFILE_DIR   override $HOME/.chrome-debug-profile
+//   CDP_WALLET_KEYCHAIN_SERVICE  override the Keychain service name
+//   CDP_WALLET_STYLUS_ENV    override packages/stylus/.env
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+const METAMASK_EXTENSION_ID = "nkbihfbeogaeaoehlefnkodbefgpgknn";
+const ARBITRUM_SEPOLIA_RPC_TIMEOUT_MS = 5000;
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+const PROFILE_DIR = process.env.CDP_WALLET_PROFILE_DIR || path.join(os.homedir(), ".chrome-debug-profile");
+const KEYCHAIN_SERVICE = process.env.CDP_WALLET_KEYCHAIN_SERVICE || "stylus-demo-metamask";
+const STYLUS_ENV_PATH = process.env.CDP_WALLET_STYLUS_ENV || path.join("packages", "stylus", ".env");
+
+const results = []; // { name, status: "OK"|"SKIP", detail, fix }
+function record(name, status, detail, fix) {
+  results.push({ name, status, detail, fix });
+  const line = `[${status}] ${name} -- ${detail}`;
+  console.log(line);
+  if (status === "SKIP") console.log(`  fix: ${fix}`);
+}
+
+// ---------------------------------------------------------------------------
+// 1. Chrome debug profile directory
+// ---------------------------------------------------------------------------
+function checkProfileDir() {
+  const name = "Chrome debug profile directory";
+  if (fs.existsSync(PROFILE_DIR) && fs.statSync(PROFILE_DIR).isDirectory()) {
+    record(name, "OK", PROFILE_DIR);
+    return true;
+  }
+  record(
+    name,
+    "SKIP",
+    `${PROFILE_DIR} does not exist`,
+    `Launch Chrome once with that profile to create it, e.g.: ` +
+      `"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --user-data-dir="${PROFILE_DIR}" ` +
+      `-- then close it and continue to Onboarding step 2 in SKILL.md.`,
+  );
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// 2. MetaMask installed in that profile
+// ---------------------------------------------------------------------------
+function checkMetaMaskInstalled() {
+  const name = "MetaMask installed in the debug profile";
+  const extDir = path.join(PROFILE_DIR, "Default", "Extensions", METAMASK_EXTENSION_ID);
+  if (!fs.existsSync(extDir)) {
+    record(
+      name,
+      "SKIP",
+      `no ${METAMASK_EXTENSION_ID} directory under ${extDir}`,
+      `Open Chrome with --user-data-dir="${PROFILE_DIR}", go to the MetaMask Chrome Web Store ` +
+        `page, and click "Add to Chrome". See SKILL.md Onboarding step 2.`,
+    );
+    return false;
+  }
+  const versions = fs.readdirSync(extDir).filter(name => fs.statSync(path.join(extDir, name)).isDirectory());
+  if (!versions.length) {
+    record(name, "SKIP", `${extDir} exists but has no version subdirectory`, `Reinstall MetaMask -- see SKILL.md Onboarding step 2.`);
+    return false;
+  }
+  const version = versions.sort().at(-1);
+  record(name, "OK", `version ${version.replace(/_0$/, "")} found at ${extDir}`);
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// 3. MetaMask vault initialised
+// ---------------------------------------------------------------------------
+//
+// IMPORTANT (measured 2026-07-22): a non-empty
+// "Local Extension Settings/<id>" directory is NOT sufficient evidence that
+// a vault exists. That directory holds ALL of chrome.storage.local for the
+// extension -- locale, telemetry consent, feature flags, snap registries --
+// which is non-empty for a freshly-installed, never-onboarded extension too.
+// On the machine this skill was designed on, that directory is >9MB and
+// non-empty, yet a live check (KeyringController.vault via a real Chrome +
+// CDP session) showed no vault and zero accounts -- MetaMask's own UI
+// confirms this by redirecting home.html to #/onboarding/welcome instead of
+// an unlock screen. A directory-size check would have reported this
+// prerequisite as satisfied when it was not: exactly the false-positive this
+// check exists to avoid. So this check does not just stat a directory --
+// it launches a short-lived headless Chrome, opens the extension's own
+// service worker, and reads chrome.storage.local directly.
+async function checkVaultInitialised() {
+  const name = "MetaMask vault initialised";
+  const extDir = path.join(PROFILE_DIR, "Default", "Extensions", METAMASK_EXTENSION_ID);
+  if (!fs.existsSync(extDir)) {
+    record(name, "SKIP", "MetaMask is not installed (see prerequisite 2 above)", "Complete prerequisite 2 first.");
+    return false;
+  }
+
+  const fixMsg =
+    "Open Chrome with --user-data-dir pointed at the debug profile, open the MetaMask extension, " +
+    "and complete setup by IMPORTING AN EXISTING SEED PHRASE for a TESTNET-ONLY account " +
+    "(never one holding mainnet funds -- this skill signs transactions without reading their contents). " +
+    "See SKILL.md Onboarding step 3.";
+
+  let vaultState;
+  try {
+    vaultState = await readVaultStateViaCdp();
+  } catch (err) {
+    // Any failure here (Chrome missing, CDP never came up, extension never
+    // registered a service worker) is reported as SKIP with the raw error --
+    // this check must never crash the whole preflight run.
+    record(name, "SKIP", `could not verify live (${err.message})`, fixMsg);
+    return false;
+  }
+
+  if (!vaultState.hasVault || vaultState.accountCount === 0) {
+    record(
+      name,
+      "SKIP",
+      `no vault / zero accounts in chrome.storage.local (hasVault=${vaultState.hasVault}, accounts=${vaultState.accountCount}, completedOnboarding=${vaultState.completedOnboarding})`,
+      fixMsg,
+    );
+    return false;
+  }
+  record(name, "OK", `vault present, ${vaultState.accountCount} account(s), completedOnboarding=${vaultState.completedOnboarding}`);
+  return true;
+}
+
+async function readVaultStateViaCdp() {
+  const { launchChrome, findFreePort, waitForCdpReady, CDP, killChromeGroup } = await import("./launch.mjs");
+  const port = await findFreePort(9222);
+  // A throwaway profile pointed at a COPY of this profile's on-disk
+  // extension would trip Chrome's content-verification (see SKILL.md
+  // "Measured unknowns" -- loading a Web-Store-installed extension's
+  // directory via --load-extension fails content_verify_job with a hash
+  // mismatch, even with _metadata stripped). So this check does not
+  // copy/relaunch the extension standalone; it opens the REAL profile
+  // directly, read-only, via chrome.storage.local -- Chrome permits only
+  // one process to hold a given user-data-dir at a time, so this must not
+  // be run concurrently with a real automation session against the same
+  // profile.
+  const chrome = launchChrome({ port, userDataDir: PROFILE_DIR, headless: true });
+  try {
+    await waitForCdpReady(port, 15000);
+    const target = await waitForServiceWorker(port, METAMASK_EXTENSION_ID, 10000);
+    const ws = new WebSocket(target.webSocketDebuggerUrl);
+    await new Promise((resolve, reject) => {
+      ws.addEventListener("open", () => resolve(), { once: true });
+      ws.addEventListener("error", e => reject(new Error(`WebSocket connect failed: ${e.message}`)), { once: true });
+    });
+    const cdp = new CDP(ws);
+    await cdp.send("Runtime.enable");
+
+    // MEASURED (2026-07-22): the service_worker target appears in /json/list
+    // slightly before the worker's top-level script has finished registering
+    // `chrome.storage` -- an evaluate() fired immediately on attach throws
+    // "Cannot read properties of undefined (reading 'local')". Retrying a
+    // few times a short distance apart clears it; there is no CDP event to
+    // wait on instead (the worker doesn't fire one for "APIs are bound").
+    let result;
+    let lastErr;
+    for (let attempt = 0; attempt < 8; attempt++) {
+      result = await cdp.send("Runtime.evaluate", {
+        expression: `
+          typeof chrome === "undefined" || typeof chrome.storage === "undefined"
+            ? Promise.reject(new Error("chrome.storage not yet bound"))
+            : new Promise((resolve) => {
+                chrome.storage.local.get(["KeyringController", "OnboardingController", "AccountsController"], (items) => {
+                  resolve({
+                    hasVault: !!(items.KeyringController && items.KeyringController.vault),
+                    accountCount: items.AccountsController && items.AccountsController.internalAccounts
+                      ? Object.keys(items.AccountsController.internalAccounts.accounts || {}).length
+                      : 0,
+                    completedOnboarding: !!(items.OnboardingController && items.OnboardingController.completedOnboarding),
+                  });
+                });
+              })
+        `,
+        awaitPromise: true,
+        returnByValue: true,
+      });
+      if (!result.exceptionDetails) break;
+      lastErr = result.exceptionDetails.exception?.description || JSON.stringify(result.exceptionDetails);
+      await sleep(400);
+    }
+    ws.close();
+    if (!result || result.exceptionDetails) {
+      throw new Error(`chrome.storage never became available on the service worker: ${lastErr}`);
+    }
+    return result.result.value;
+  } finally {
+    await killChromeGroup(chrome.pid);
+  }
+}
+
+async function waitForServiceWorker(port, extensionId, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const list = await fetch(`http://127.0.0.1:${port}/json/list`).then(r => r.json());
+    const target = list.find(t => t.type === "service_worker" && t.url.includes(extensionId));
+    if (target) return target;
+    await new Promise(r => setTimeout(r, 300));
+  }
+  throw new Error(`MetaMask service worker never appeared within ${timeoutMs}ms`);
+}
+
+// ---------------------------------------------------------------------------
+// 4. Keychain entry present
+// ---------------------------------------------------------------------------
+function checkKeychainEntry() {
+  const name = "Keychain entry present";
+  try {
+    // Existence check ONLY -- never pass -w here, which would print the
+    // password to stdout.
+    execFileSync("security", ["find-generic-password", "-s", KEYCHAIN_SERVICE], { stdio: "ignore" });
+    record(name, "OK", `security find-generic-password -s ${KEYCHAIN_SERVICE} exits 0`);
+    return true;
+  } catch {
+    record(
+      name,
+      "SKIP",
+      `no Keychain item named "${KEYCHAIN_SERVICE}"`,
+      `security add-generic-password -s ${KEYCHAIN_SERVICE} -a "$USER" -w  ` +
+        `(this prompts for the password interactively -- it is never echoed and never touches shell history; ` +
+        `do NOT pass -w <password> as a literal argument).`,
+    );
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 5. Arbitrum Sepolia RPC reachable via packages/stylus/.env
+// ---------------------------------------------------------------------------
+async function checkSepoliaRpc() {
+  const name = "Arbitrum Sepolia RPC reachable";
+  const fixMsg =
+    `cp packages/stylus/.env.example packages/stylus/.env (if it doesn't exist yet), then fill in ` +
+    `RPC_URL_SEPOLIA in the "## sepolia" block. A public endpoint (e.g. https://sepolia-rollup.arbitrum.io/rpc) works.`;
+
+  if (!fs.existsSync(STYLUS_ENV_PATH)) {
+    record(name, "SKIP", `${STYLUS_ENV_PATH} does not exist`, fixMsg);
+    return false;
+  }
+  const envText = fs.readFileSync(STYLUS_ENV_PATH, "utf8");
+  const match = envText.match(/^RPC_URL_SEPOLIA=(.+)$/m);
+  const rpcUrl = match ? match[1].trim() : "";
+  if (!rpcUrl) {
+    record(name, "SKIP", `${STYLUS_ENV_PATH} exists but RPC_URL_SEPOLIA is blank/absent`, fixMsg);
+    return false;
+  }
+
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), ARBITRUM_SEPOLIA_RPC_TIMEOUT_MS);
+    const res = await fetch(rpcUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_chainId", params: [] }),
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+    const body = await res.json();
+    const chainId = body.result;
+    if (chainId !== "0x66eee") {
+      record(name, "SKIP", `RPC responded but chainId ${chainId} != Arbitrum Sepolia's 0x66eee`, `Point RPC_URL_SEPOLIA at an Arbitrum Sepolia endpoint.`);
+      return false;
+    }
+    record(name, "OK", `${rpcUrl} reachable, chainId=0x66eee`);
+    return true;
+  } catch (err) {
+    record(name, "SKIP", `RPC_URL_SEPOLIA set but unreachable (${err.message})`, `Check connectivity / the URL itself. ${fixMsg}`);
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+async function main() {
+  console.log("=== cdp-with-wallet preflight ===");
+  console.log(`Profile dir: ${PROFILE_DIR}`);
+  console.log("");
+
+  checkProfileDir();
+  checkMetaMaskInstalled();
+  await checkVaultInitialised();
+  checkKeychainEntry();
+  await checkSepoliaRpc();
+
+  console.log("");
+  const skipped = results.filter(r => r.status === "SKIP");
+  if (skipped.length) {
+    console.log(`NOT READY: ${skipped.length}/${results.length} prerequisite(s) missing (see SKIP lines above for exact fixes).`);
+    process.exit(1);
+  }
+  console.log(`READY: all ${results.length} prerequisites satisfied.`);
+  process.exit(0);
+}
+
+main();

--- a/.claude/skills/cdp-with-wallet/preflight.mjs
+++ b/.claude/skills/cdp-with-wallet/preflight.mjs
@@ -15,11 +15,19 @@
 // Usage:
 //   node .claude/skills/cdp-with-wallet/preflight.mjs
 //
-// Exit codes:
-//   0 - every prerequisite satisfied, skill is ready to run
-//   1 - one or more prerequisites are missing (see per-check SKIP lines above
-//       the summary for the exact fix). This is NOT a crash -- it is the
-//       expected result on a machine that hasn't been onboarded yet.
+// Exit codes -- three-way, not binary (adopted from scaffold-stark,
+// 2026-07-22): a bare 0/1 conflates "this machine is missing a real
+// prerequisite" with "the network hiccuped just now", and a gate that goes
+// red on things nobody controls is a gate people learn to ignore.
+//   0 - GREEN:  every prerequisite satisfied, skill is ready to run.
+//   1 - RED:    at least one real, fixable prerequisite is missing (no
+//       vault, no/wrong Keychain entry, MetaMask not installed, etc) --
+//       see per-check SKIP lines above the summary for the exact fix. This
+//       is NOT a crash, and callers SHOULD block on it.
+//   2 - INFRA:  every SKIP is environmental (Sepolia RPC unreachable,
+//       another Chrome window holding the debug profile) -- not a defect
+//       in this machine's setup, may resolve on its own. Callers MAY choose
+//       not to block on this one, e.g. retry rather than hard-fail CI.
 //
 // Env var overrides (for testing the absent case WITHOUT touching the real
 // profile/Keychain/env file -- never delete or edit the real ones to test
@@ -65,12 +73,34 @@ function mainCheckoutRoot() {
   }
 }
 
-const results = []; // { name, status: "OK"|"SKIP", detail, fix }
-function record(name, status, detail, fix) {
-  results.push({ name, status, detail, fix });
+// Three-way exit classification (adopted from scaffold-stark, 2026-07-22):
+// a SKIP is not one thing. "No vault initialised" and "Sepolia RPC
+// unreachable" look identical as a bare exit(1) -- but the first is a real,
+// fixable machine-setup gap (RED) and the second may just be a transient
+// network blip or someone else's Chrome window (INFRA). Collapsing them into
+// one exit code means a caller either blocks on both (and learns to ignore
+// the gate when infra flakes) or blocks on neither (and misses a genuine
+// setup problem). category defaults to "RED" -- only the specific checks
+// that are about environment/timing rather than this machine's own
+// configuration pass "INFRA" explicitly.
+const results = []; // { name, status: "OK"|"SKIP", detail, fix, category }
+function record(name, status, detail, fix, category = "RED") {
+  results.push({ name, status, detail, fix, category });
   const line = `[${status}] ${name} -- ${detail}`;
   console.log(line);
   if (status === "SKIP") console.log(`  fix: ${fix}`);
+}
+
+// withChromeOnRealProfile() throws one specific, named error for "someone
+// else's Chrome is currently holding this profile" (see its own comment) --
+// that's a transient state a human closing a window fixes, not a machine
+// mis-setup, so it gets INFRA rather than RED. Every other failure out of
+// that helper (Chrome crashed, CDP never came up for an unknown reason,
+// extension never registered a service worker) stays RED: those indicate
+// something is actually broken about this machine's Chrome/extension setup,
+// not just bad timing.
+function categoryForChromeError(err) {
+  return /already using this profile/.test(err.message) ? "INFRA" : "RED";
 }
 
 // ---------------------------------------------------------------------------
@@ -158,7 +188,7 @@ async function checkVaultInitialised() {
     // Any failure here (Chrome missing, CDP never came up, extension never
     // registered a service worker) is reported as SKIP with the raw error --
     // this check must never crash the whole preflight run.
-    record(name, "SKIP", `could not verify live (${err.message})`, fixMsg);
+    record(name, "SKIP", `could not verify live (${err.message})`, fixMsg, categoryForChromeError(err));
     return false;
   }
 
@@ -368,7 +398,13 @@ async function checkKeychainEntry(vaultOk) {
           `provisioned, the MetaMask password later during onboarding -- so nothing keeps them in sync automatically.`,
       );
     } else {
-      record(name, "SKIP", `could not verify live (${err.message})`, `Investigate the error above; this is not a missing-prerequisite case.`);
+      record(
+        name,
+        "SKIP",
+        `could not verify live (${err.message})`,
+        `Investigate the error above; this is not a missing-prerequisite case.`,
+        categoryForChromeError(err),
+      );
     }
     return false;
   }
@@ -414,7 +450,12 @@ async function checkSepoliaRpc() {
     record(name, "OK", `${rpcUrl} reachable, chainId=0x66eee`);
     return true;
   } catch (err) {
-    record(name, "SKIP", `RPC_URL_SEPOLIA set but unreachable (${err.message})`, `Check connectivity / the URL itself. ${fixMsg}`);
+    // Unreachable is the canonical INFRA case: a transient network blip, a
+    // rate limit, or the public endpoint being temporarily down are not
+    // this machine's fault and often resolve on their own -- unlike a wrong
+    // chainId or a blank .env value above, which are real misconfiguration
+    // (RED, the default).
+    record(name, "SKIP", `RPC_URL_SEPOLIA set but unreachable (${err.message})`, `Check connectivity / the URL itself. ${fixMsg}`, "INFRA");
     return false;
   }
 }
@@ -435,12 +476,29 @@ async function main() {
 
   console.log("");
   const skipped = results.filter(r => r.status === "SKIP");
-  if (skipped.length) {
-    console.log(`NOT READY: ${skipped.length}/${results.length} prerequisite(s) missing (see SKIP lines above for exact fixes).`);
+  const redSkips = skipped.filter(r => r.category === "RED");
+  const infraSkips = skipped.filter(r => r.category === "INFRA");
+
+  if (!skipped.length) {
+    console.log(`READY (exit 0): all ${results.length} prerequisites satisfied.`);
+    process.exit(0);
+  }
+  if (redSkips.length) {
+    // RED wins even if INFRA skips are ALSO present -- a real setup gap
+    // needs fixing regardless of what else happened to be flaky this run.
+    console.log(
+      `NOT READY (exit 1, RED): ${redSkips.length} real problem(s) to fix` +
+        (infraSkips.length ? ` (plus ${infraSkips.length} environmental issue(s), see below)` : "") +
+        ` -- see SKIP lines above for exact fixes.`,
+    );
     process.exit(1);
   }
-  console.log(`READY: all ${results.length} prerequisites satisfied.`);
-  process.exit(0);
+  console.log(
+    `NOT READY (exit 2, INFRA): ${infraSkips.length} environmental issue(s) -- not a code or config defect on this ` +
+      `machine, may resolve on retry (network blip, another Chrome window, rate limit). Callers may choose not to ` +
+      `block on this exit code.`,
+  );
+  process.exit(2);
 }
 
 main();

--- a/.claude/skills/cdp-with-wallet/preflight.mjs
+++ b/.claude/skills/cdp-with-wallet/preflight.mjs
@@ -39,7 +39,31 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const PROFILE_DIR = process.env.CDP_WALLET_PROFILE_DIR || path.join(os.homedir(), ".chrome-debug-profile");
 const KEYCHAIN_SERVICE = process.env.CDP_WALLET_KEYCHAIN_SERVICE || "stylus-demo-metamask";
-const STYLUS_ENV_PATH = process.env.CDP_WALLET_STYLUS_ENV || path.join("packages", "stylus", ".env");
+const STYLUS_ENV_PATH = process.env.CDP_WALLET_STYLUS_ENV || path.join(mainCheckoutRoot(), "packages", "stylus", ".env");
+
+// MEASURED (2026-07-22): resolving packages/stylus/.env against process.cwd()
+// gives a false SKIP when this skill is run from a git worktree -- .env is
+// untracked, so it only exists in whichever checkout a human actually put it
+// in (normally the main one), never in a worktree's own copy of the tree.
+// `git rev-parse --git-common-dir` always points at the ONE shared .git dir
+// for a repo, from either the main checkout or any of its worktrees; its
+// parent is the main checkout's root in both cases (verified: run from the
+// worktree it printed the main repo's absolute .git path, not the worktree's
+// own; run from the main checkout it printed the same path either way once
+// --path-format=absolute is passed).
+function mainCheckoutRoot() {
+  try {
+    const gitCommonDir = execFileSync("git", ["rev-parse", "--path-format=absolute", "--git-common-dir"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+    }).trim();
+    return path.dirname(gitCommonDir);
+  } catch {
+    // Not inside a git repo (or git missing) -- fall back to cwd, same as
+    // the previous behavior, rather than crashing the whole preflight run.
+    return process.cwd();
+  }
+}
 
 const results = []; // { name, status: "OK"|"SKIP", detail, fix }
 function record(name, status, detail, fix) {
@@ -151,8 +175,47 @@ async function checkVaultInitialised() {
   return true;
 }
 
+// MEASURED (2026-07-22): Chrome only allows one process to hold a given
+// --user-data-dir at a time. If a human already has that profile open
+// (their normal interactive browsing session, no --remote-debugging-port),
+// launching a second Chrome against it never gets a CDP port up -- it just
+// times out. Without this check, that surfaces as
+// "Chrome's CDP endpoint never became reachable (fetch failed)", which
+// reads like a broken launcher or a network problem, and sends the next
+// person hunting for a bug that isn't there. This is the same failure
+// shape smoke-test hit before: Step 9c's balance gate misdiagnosed a
+// missing `cast` binary as "Sepolia RPC unreachable" -- right symptom,
+// wrong cause. Detecting the actual conflicting process up front and
+// naming its PID is the fix, same as here.
+function findChromeUsingProfile(profileDir) {
+  let psOutput;
+  try {
+    psOutput = execFileSync("ps", ["-ax", "-o", "pid=,command="], { encoding: "utf8" });
+  } catch {
+    return null; // ps itself failing is not this check's problem to diagnose
+  }
+  for (const line of psOutput.split("\n")) {
+    // Match the main browser binary specifically (trailing space excludes
+    // "Google Chrome Helper" et al, which also carry --user-data-dir).
+    if (!line.includes("Contents/MacOS/Google Chrome ")) continue;
+    if (!line.includes(`--user-data-dir=${profileDir}`)) continue;
+    const match = line.trim().match(/^(\d+)\s/);
+    if (match) return { pid: match[1], command: line.trim() };
+  }
+  return null;
+}
+
 async function readVaultStateViaCdp() {
   const { launchChrome, findFreePort, waitForCdpReady, CDP, killChromeGroup } = await import("./launch.mjs");
+
+  const conflict = findChromeUsingProfile(PROFILE_DIR);
+  if (conflict) {
+    throw new Error(
+      `another Chrome is already using this profile (PID ${conflict.pid}) -- quit it with Cmd+Q ` +
+        `(not just closing the window) and re-run`,
+    );
+  }
+
   const port = await findFreePort(9222);
   // A throwaway profile pointed at a COPY of this profile's on-disk
   // extension would trip Chrome's content-verification (see SKILL.md
@@ -166,6 +229,10 @@ async function readVaultStateViaCdp() {
   // profile.
   const chrome = launchChrome({ port, userDataDir: PROFILE_DIR, headless: true });
   try {
+    // If the timeout below fires, it means CDP genuinely never came up for
+    // some OTHER reason (Chrome crashed, a firewall rule, etc) -- the
+    // conflicting-process case is already ruled out above, so this message
+    // stays generic and the two causes stay distinguishable.
     await waitForCdpReady(port, 15000);
     const target = await waitForServiceWorker(port, METAMASK_EXTENSION_ID, 10000);
     const ws = new WebSocket(target.webSocketDebuggerUrl);

--- a/.claude/skills/cdp-with-wallet/preflight.mjs
+++ b/.claude/skills/cdp-with-wallet/preflight.mjs
@@ -205,8 +205,11 @@ function findChromeUsingProfile(profileDir) {
   return null;
 }
 
-async function readVaultStateViaCdp() {
-  const { launchChrome, findFreePort, waitForCdpReady, CDP, killChromeGroup } = await import("./launch.mjs");
+// Shared by both the vault-read check and the live-unlock check below --
+// both need a Chrome process against the REAL profile, both need the same
+// conflicting-process guard, both must always kill what they launched.
+async function withChromeOnRealProfile(callback) {
+  const { launchChrome, findFreePort, waitForCdpReady, killChromeGroup } = await import("./launch.mjs");
 
   const conflict = findChromeUsingProfile(PROFILE_DIR);
   if (conflict) {
@@ -221,19 +224,27 @@ async function readVaultStateViaCdp() {
   // extension would trip Chrome's content-verification (see SKILL.md
   // "Measured unknowns" -- loading a Web-Store-installed extension's
   // directory via --load-extension fails content_verify_job with a hash
-  // mismatch, even with _metadata stripped). So this check does not
-  // copy/relaunch the extension standalone; it opens the REAL profile
-  // directly, read-only, via chrome.storage.local -- Chrome permits only
-  // one process to hold a given user-data-dir at a time, so this must not
-  // be run concurrently with a real automation session against the same
-  // profile.
+  // mismatch, even with _metadata stripped). So these checks do not
+  // copy/relaunch the extension standalone; they open the REAL profile
+  // directly -- Chrome permits only one process to hold a given
+  // user-data-dir at a time, so this must not be run concurrently with a
+  // real automation session against the same profile.
   const chrome = launchChrome({ port, userDataDir: PROFILE_DIR, headless: true });
   try {
     // If the timeout below fires, it means CDP genuinely never came up for
     // some OTHER reason (Chrome crashed, a firewall rule, etc) -- the
-    // conflicting-process case is already ruled out above, so this message
-    // stays generic and the two causes stay distinguishable.
+    // conflicting-process case is already ruled out above, so that timeout
+    // message stays generic and the two causes stay distinguishable.
     await waitForCdpReady(port, 15000);
+    return await callback(port);
+  } finally {
+    await killChromeGroup(chrome.pid);
+  }
+}
+
+async function readVaultStateViaCdp() {
+  const { CDP } = await import("./launch.mjs");
+  return withChromeOnRealProfile(async port => {
     const target = await waitForServiceWorker(port, METAMASK_EXTENSION_ID, 10000);
     const ws = new WebSocket(target.webSocketDebuggerUrl);
     await new Promise((resolve, reject) => {
@@ -280,9 +291,7 @@ async function readVaultStateViaCdp() {
       throw new Error(`chrome.storage never became available on the service worker: ${lastErr}`);
     }
     return result.result.value;
-  } finally {
-    await killChromeGroup(chrome.pid);
-  }
+  });
 }
 
 async function waitForServiceWorker(port, extensionId, timeoutMs) {
@@ -297,16 +306,32 @@ async function waitForServiceWorker(port, extensionId, timeoutMs) {
 }
 
 // ---------------------------------------------------------------------------
-// 4. Keychain entry present
+// 4. Keychain entry present AND correct
 // ---------------------------------------------------------------------------
-function checkKeychainEntry() {
-  const name = "Keychain entry present";
+//
+// MEASURED (2026-07-22): an existence-only check is not enough. On this
+// machine the Keychain item existed (created earlier in the session) but
+// held a DIFFERENT value than the password actually set during MetaMask
+// onboarding (set later, at a different moment) -- preflight reported OK,
+// and unlock() failed several steps downstream with a confusing
+// "MetaMask rejected the password" error. That is the exact same failure
+// shape as check 3's "non-empty directory != initialised vault": a cheap
+// proxy that looks like it proves the real thing but doesn't. The fix here
+// is the same kind -- verify the password actually WORKS by attempting a
+// real unlock, not just that some value is stored under that name.
+//
+// This needs prerequisite 3 (vault initialised) to have already passed --
+// there is nothing to unlock otherwise -- so `vaultOk` gates the live
+// attempt; call this AFTER checkVaultInitialised(), passing its result.
+async function checkKeychainEntry(vaultOk) {
+  const name = "Keychain entry present and correct";
+  let password;
   try {
-    // Existence check ONLY -- never pass -w here, which would print the
-    // password to stdout.
-    execFileSync("security", ["find-generic-password", "-s", KEYCHAIN_SERVICE], { stdio: "ignore" });
-    record(name, "OK", `security find-generic-password -s ${KEYCHAIN_SERVICE} exits 0`);
-    return true;
+    // Read in-process via execFileSync -- never through a shell command
+    // substitution passed as an argv (that would land the password in `ps`
+    // output for the life of the process) and never printed/logged, only
+    // its length ever appears below.
+    password = execFileSync("security", ["find-generic-password", "-s", KEYCHAIN_SERVICE, "-w"], { encoding: "utf8" }).trim();
   } catch {
     record(
       name,
@@ -316,6 +341,35 @@ function checkKeychainEntry() {
         `(this prompts for the password interactively -- it is never echoed and never touches shell history; ` +
         `do NOT pass -w <password> as a literal argument).`,
     );
+    return false;
+  }
+
+  if (!vaultOk) {
+    // Nothing to unlock yet -- fall back to existence-only, same as the
+    // previous behavior, rather than blocking on prerequisite 3's own SKIP.
+    record(name, "OK", `entry present (length ${password.length}) -- vault not initialised yet, so password correctness could not be verified (see prerequisite 3)`);
+    return true;
+  }
+
+  const { unlock, IncorrectPasswordError } = await import("./metamask.mjs");
+  try {
+    const result = await withChromeOnRealProfile(port => unlock({ port, extensionId: METAMASK_EXTENSION_ID, password }));
+    record(name, "OK", `entry present (length ${password.length}) and successfully unlocked the vault (alreadyUnlocked=${result.alreadyUnlocked})`);
+    return true;
+  } catch (err) {
+    if (err instanceof IncorrectPasswordError) {
+      record(
+        name,
+        "SKIP",
+        `entry present (length ${password.length}) but MetaMask rejected it -- the stored value does not match this vault's actual password`,
+        `security add-generic-password -U -s ${KEYCHAIN_SERVICE} -a "$USER" -w  ` +
+          `(the -U flag updates the existing item; set it to the SAME password you use to unlock MetaMask by hand). ` +
+          `This drifts because the two are set at different moments -- the Keychain entry when this machine was first ` +
+          `provisioned, the MetaMask password later during onboarding -- so nothing keeps them in sync automatically.`,
+      );
+    } else {
+      record(name, "SKIP", `could not verify live (${err.message})`, `Investigate the error above; this is not a missing-prerequisite case.`);
+    }
     return false;
   }
 }
@@ -375,8 +429,8 @@ async function main() {
 
   checkProfileDir();
   checkMetaMaskInstalled();
-  await checkVaultInitialised();
-  checkKeychainEntry();
+  const vaultOk = await checkVaultInitialised();
+  await checkKeychainEntry(vaultOk);
   await checkSepoliaRpc();
 
   console.log("");

--- a/.claude/skills/demo-video/SKILL.md
+++ b/.claude/skills/demo-video/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: demo-video
+description: Use when asked to record a demo video proving scaffold-stylus works end to end — a terminal take of a real Arbitrum Sepolia deploy, and a browser take of a real MetaMask wallet connecting and sending a write transaction against that deploy. Triggers on requests to record a demo, produce a proof video, or show a real deploy + wallet flow on camera.
+---
+
+# demo-video
+
+## Overview
+
+Gian asked for a video demonstrating that scaffold-stylus actually works.
+`smoke-test`'s Step 9 already proves a real Arbitrum Sepolia deploy, and
+`.claude/skills/cdp-with-wallet` proves a real MetaMask wallet can be
+driven end to end without a human clicking the extension popup. This
+skill records both as two takes:
+
+1. **Take 1 (terminal)** — wraps smoke-test Step 9 *exactly as it already
+   exists* (9a–9e; 9f is deferred, see "Sequencing" below), recorded with
+   `asciinema`.
+2. **Take 2 (browser)** — drives a real MetaMask connect + write tx
+   against the contract Take 1 just deployed, via `cdp-with-wallet`'s
+   primitives, recorded with Chrome DevTools Protocol's own
+   `Page.startScreencast`.
+
+Zero npm dependencies, matching `.claude/skills/smoke-test/browser-e2e.mjs`
+and `.claude/skills/cdp-with-wallet/*.mjs`.
+
+## Files
+
+```
+.claude/skills/demo-video/
+  SKILL.md    this file
+  record.mjs  orchestrates take 1, take 2, and cleanup
+  step9.sh    the ACTUAL smoke-test Step 9 procedure (9a-9e), invoked by
+              record.mjs under `asciinema record` -- not a parallel/demo-
+              only script. If this drifts from Step 9 as documented in
+              smoke-test's own SKILL.md, that is a bug here, not an
+              acceptable shortcut: the whole point of wrapping the real
+              procedure is that the recording and the test cannot drift
+              apart.
+```
+
+## Prerequisites
+
+Everything `cdp-with-wallet` needs (run `node
+.claude/skills/cdp-with-wallet/preflight.mjs` first — see its own SKILL.md
+for the three-way exit code), plus:
+
+```bash
+brew install asciinema agg ffmpeg
+```
+
+Versions this was built and measured against: `asciinema` 3.2.1, `agg`
+1.9.0, `ffmpeg` 8.1.2.
+
+## Usage
+
+```bash
+node .claude/skills/demo-video/record.mjs all --branch=<branch-you-are-demoing>
+node .claude/skills/demo-video/record.mjs take1 --branch=<branch>   # terminal only
+node .claude/skills/demo-video/record.mjs take2 --branch=<branch>   # browser only (needs take1 to have run first)
+node .claude/skills/demo-video/record.mjs cleanup                    # escape hatch after a crashed run
+```
+
+`--branch` (or `DEMO_VIDEO_BRANCH`) is **required** for `all`/`take1`/
+`take2` — see "Why the base branch must be stated" below. `--pr=<number>`
+lets the proof block (see "Why the proof block exists") post automatically
+via `gh pr comment`; without it, the block is still generated and printed,
+just not posted.
+
+Artifacts land in `~/Desktop/stylus-demo-<YYYY-MM-DD>/` (override with
+`DEMO_VIDEO_OUTDIR`), following the smoke-test screenshot precedent.
+**Videos/GIFs/casts are never committed** — add ignore rules if a repo's
+`.gitignore` doesn't already cover `~/Desktop`.
+
+## Why the base branch must be stated
+
+**This is the one lesson from building this skill that must not recur.**
+The first full recording cycle on 2026-07-22 was run against `main`
+without ever stating that on purpose — it happened to be the branch
+checked out at the time, not a deliberate choice. `main` still had a
+removed-elsewhere Uniswap price-fetch feature throwing errors, none of the
+ENS-gating or block-explorer-pagination fixes that had already landed on
+`release/phase-1`, and (unrelated but compounding) a real gas-fee bug on
+the Debug page that made the write transaction fail outright. The
+recording was fully valid — it played, the tx hash was real — and would
+have shown Gian exactly the wrong code while asking him to approve
+different code. **A demo recorded from the wrong branch looks completely
+valid and is silently worthless; there is no way to tell from the video
+itself that it proves the wrong thing.**
+
+So `record.mjs`'s very first step (`requireStatedBranch()`) refuses to
+record at all until the target branch is stated explicitly — via
+`--branch=<name>` or `DEMO_VIDEO_BRANCH` — and that value is checked
+against what's actually checked out (`git rev-parse --abbrev-ref HEAD`),
+catching the second-order mistake of stating one branch while sitting on
+another. This is a preflight gate, not a comment: it `process.exit(3)`s
+with the actual checked-out branch and the exact flag to re-run with, the
+same SKIP-not-crash contract as smoke-test's own gates. The branch and
+commit SHA are then stamped into both artifacts (asciinema's `--title`,
+the mp4's `-metadata comment`) so the artifact itself identifies its
+source — a reviewer doesn't have to trust a claim made elsewhere about
+what a video shows.
+
+## Why the proof block exists
+
+A video on its own proves nothing to a reviewer — it's a recording of
+pixels. Nobody reviewing a PR can independently verify a claim from
+watching one. The tx hashes, the arbiscan links, and the raw on-chain
+read-back (a fresh `cast call`, not just the dapp's own UI reading its own
+write back to itself) **are** the actual proof: a reviewer can paste a
+hash into arbiscan or run the same `cast call` and get the same answer
+this skill got. That evidence is only useful if it travels **with** the
+PR automatically — a human copying hashes around after the fact is
+exactly the step that gets skipped under time pressure and forgotten.
+
+So after a successful run, `record.mjs` emits a ready-to-paste markdown
+block (contract address, every tx hash with its
+`https://sepolia.arbiscan.io/tx/<hash>` link, the independent on-chain
+read-back, the video's duration vs. the run's wall-clock duration, and the
+branch + commit it was recorded from) and posts it to the PR itself via
+`gh pr comment` when one is found for the current branch (or given
+explicitly with `--pr=<number>`) — not just printing it for a human to
+relay.
+
+**Known limitation, stated plainly rather than worked around: `gh` cannot
+attach video or image files to a PR body or comment — only text (links,
+hashes) travels this way.** The actual `.mp4`/`.gif` files still need a
+human to drag them into the GitHub web UI (a PR comment's edit box, or a
+release asset). The proof block carries everything *except* the media
+itself, and says so in its own last line.
+
+## Sequencing — read before changing the flow
+
+Take 2 needs `packages/nextjs/contracts/deployedContracts.ts` to contain
+the Sepolia entry Take 1 just deployed, or the app has no contract to
+show. But smoke-test Step 9f restores that file as cleanup. So the order
+is: **Take 1 (9a–9e only) → Take 2 → cleanup (9f-equivalent, plus
+restoring `scaffold.config.ts` and any newly-dirtied `next-env.d.ts`)**.
+`cleanupAll()` runs in a `finally` in `main()`'s `all` mode, so it fires
+regardless of outcome. Running `take1`/`take2` standalone skips this
+cleanup on purpose (so you can inspect state between them by hand); use
+`cleanup` as the explicit escape hatch afterward.
+
+`packages/nextjs/next-env.d.ts` may already be dirty before this skill
+ever runs (Next.js rewrites it on its own) — its baseline dirtiness is
+captured before Take 1/Take 2 run and only restored if it was clean at
+that baseline, so a developer's own pre-existing change there is never
+silently discarded.
+
+## Why CDP screencast, not macOS `screencapture -v`
+
+The original design used macOS `screencapture -v` for Take 2. That
+requires the Screen Recording TCC permission for whichever app hosts the
+invoking process. Mid-build, that permission was granted but had **not**
+taken effect — macOS only applies a TCC grant when the process restarts,
+and the host app was not restarted — yet a probe recording still
+succeeded (ffprobe-verified real duration/dimensions/frame-count; visually
+confirmed non-black content). Given that ambiguity and the cost of
+restarting a session with many other things running in it, the call was
+made to switch to CDP's own `Page.startScreencast` instead: it captures
+frames from inside Chrome, needs no OS permission at all, works headless,
+and works in CI (a physical screen recording never could). This is the
+approach actually implemented — `record.mjs` never shells out to
+`screencapture`.
+
+One consequence: `cdp-with-wallet`'s `launchChrome()` can stay at its
+default `headless: true` for this skill too — an earlier version of that
+skill's own docs said recording needed `headless: false`; that guidance
+predated this switch and has been corrected in `cdp-with-wallet/SKILL.md`
+and `launch.mjs`.
+
+## The frame-timing trap (measured, not assumed)
+
+`Page.screencastFrame` does **not** fire at a fixed rate — only when the
+page actually repaints — and each frame must be acknowledged via
+`Page.screencastFrameAck` or the stream stalls. A first implementation
+assembled frames into a video using ffmpeg's concat demuxer with a
+per-frame `duration` computed from the gap to the next frame's timestamp,
+floored at 50ms to avoid a zero-duration entry. **Measured result: a real
+11.1-second run assembled into a 27-second video (2.4x too long).** Most
+of the 456 captured frames arrived faster than 50ms apart (real UI
+repaints during the connect/switch/write flow), so flooring every one of
+those sub-50ms gaps to 50ms compounded across hundreds of frames into a
+video whose timing had nothing to do with what actually happened — a
+valid file that plays, silently wrong. The floor was lowered to 1ms (just
+enough for ffmpeg's concat demuxer to accept a positive duration, not
+"watchable per frame"); re-verified: a 10.84s video against a 10.77s
+wall-clock run, and later a 12.08s video against a 12.02s run. **Always
+report both numbers — video duration and the run's own wall-clock
+duration — side by side; a value that plays with no comparison is not
+evidence they match.**
+
+If a run fails after the screencast has started, whatever frames were
+captured are still assembled and saved as a partial video (with the error
+printed alongside) rather than discarded — a partial recording someone
+can point at and say "it stops here, that's the bug" beats a clean
+failure with zero artifact.
+
+## Measured — the four items the design called out up front
+
+1. **`agg` 1.9.0 vs asciicast-v3.** Measured **works directly** — `agg`
+   read a real asciicast-v3 recording (the default format for asciinema
+   3.x) with no conversion needed. `--output-format asciicast-v2` is not
+   required.
+2. **asciinema 3.x CLI.** Confirmed via `asciinema record --help` on this
+   machine: the subcommand is `asciinema record <FILE>` (not `rec`), and
+   `--command`, `--title`, `--output-format`, `--return`, and `--overwrite`
+   all behave as documented. `--return` is what lets `record.mjs` read
+   Step 9's real exit code without a separate tee/pipefail dance.
+3. **`screencapture -v` and the Screen Recording permission.** Measured
+   as described above under "Why CDP screencast, not screencapture" —
+   this became moot once the design switched away from `screencapture`
+   entirely.
+4. **Recording a window vs. the whole screen.** Also moot for the same
+   reason — CDP screencast captures a specific page's rendered content
+   directly, not a physical display region at all.
+
+## The staleness trap — "the artifact exists" is not "the artifact is from THIS run"
+
+`packages/stylus/deployments/421614_latest.json` and
+`packages/nextjs/contracts/deployedContracts.ts` both persist across runs
+by design (smoke-test's own Step 8 only deletes them on PASS). This means
+a deploy command that exits 0 without actually rewriting one of them would
+otherwise let a later check silently re-verify a **previous** run's
+deployment and report PASS — the same failure shape as reading a
+non-empty extension-settings directory as "vault initialised", or a
+present Keychain entry as "password correct" (both traps `cdp-with-wallet`
+hit and fixed the same day this skill was built). Two independent
+cross-checks guard against it here:
+
+- `step9.sh` captures `yarn deploy`'s own stdout and cross-checks the
+  address/tx hash it prints against what's in
+  `deployments/421614_latest.json` — mismatch or unparseable stdout is
+  **FAIL**, not PASS.
+- `take1()` in `record.mjs` separately cross-checks that
+  `deployedContracts.ts` — a different file, written by a different step
+  of the same `yarn deploy` invocation — actually contains this run's
+  deployed address before calling Take 1 PASS, since Take 2 renders from
+  that file specifically.
+
+(The equivalent gap in `smoke-test` itself — Step 4's local-devnode deploy,
+and Step 9d/9e's Sepolia deploy read-back — was reported to the captain
+separately; this skill's own artifacts are what's fixed here.)

--- a/.claude/skills/demo-video/record.mjs
+++ b/.claude/skills/demo-video/record.mjs
@@ -1,0 +1,577 @@
+#!/usr/bin/env node
+// .claude/skills/demo-video/record.mjs
+//
+// Orchestrates the two demo-video takes:
+//   Take 1 -- terminal: wraps smoke-test Step 9 (Sepolia deploy) exactly as
+//             it already exists, recorded with asciinema.
+//   Take 2 -- browser: drives a real MetaMask connect + write tx against the
+//             just-deployed Sepolia contract via cdp-with-wallet, recorded
+//             with CDP's own Page.startScreencast (NOT macOS screencapture --
+//             see SKILL.md "Why CDP screencast, not screencapture").
+//
+// Sequencing (the "sequencing trap" from the spec): Step 9's own cleanup
+// (9f, restoring packages/nextjs/contracts/deployedContracts.ts) is deferred
+// until AFTER Take 2 runs, because Take 2 needs that file's Sepolia entry to
+// have anything to show in the frontend. See cleanupAll() below, which is
+// the only place 9f-equivalent cleanup happens, run in a `finally` so it
+// fires regardless of outcome.
+//
+// Zero npm dependencies, matching .claude/skills/smoke-test/browser-e2e.mjs
+// and .claude/skills/cdp-with-wallet/*.mjs.
+//
+// Usage:
+//   node record.mjs all        -- take1, then take2, then cleanup (default)
+//   node record.mjs take1      -- terminal take only (no cleanup -- leaves
+//                                  deployedContracts.ts with the Sepolia
+//                                  entry on purpose, for a manual take2)
+//   node record.mjs take2      -- browser take only (assumes take1 already
+//                                  ran and deployedContracts.ts has the
+//                                  Sepolia entry)
+//   node record.mjs cleanup    -- restore scaffold.config.ts /
+//                                  deployedContracts.ts, kill any leaked
+//                                  frontend/Chrome -- the escape hatch if a
+//                                  run crashed mid-flight
+
+import { execFileSync, spawn, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  CDP,
+  evaluate,
+  findFreePort,
+  isolateExtensions,
+  killChromeGroup,
+  launchChrome,
+  METAMASK_EXTENSION_ID,
+  restoreExtensions,
+  waitForCdpReady,
+} from "../cdp-with-wallet/launch.mjs";
+import { approveTx, connect, unlock } from "../cdp-with-wallet/metamask.mjs";
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+// ---------------------------------------------------------------------------
+// Path resolution -- same git-common-dir technique as cdp-with-wallet's
+// preflight.mjs. packages/stylus/.env is untracked and normally only exists
+// in the main checkout, never in a worktree's own copy of the tree; this
+// skill is meant to be run from either.
+// ---------------------------------------------------------------------------
+function mainCheckoutRoot() {
+  try {
+    const gitCommonDir = execFileSync("git", ["rev-parse", "--path-format=absolute", "--git-common-dir"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+    }).trim();
+    return path.dirname(gitCommonDir);
+  } catch {
+    return process.cwd();
+  }
+}
+
+function worktreeRoot() {
+  return execFileSync("git", ["rev-parse", "--show-toplevel"], { cwd: process.cwd(), encoding: "utf8" }).trim();
+}
+
+// Regex-per-key extraction, matching preflight.mjs's own style -- no dotenv
+// dependency on this side (packages/stylus/scripts/utils/network.ts already
+// depends on dotenv itself; that's the existing codebase, not this script).
+function readStylusEnvKey(envPath, key) {
+  if (!fs.existsSync(envPath)) return undefined;
+  const text = fs.readFileSync(envPath, "utf8");
+  const match = text.match(new RegExp(`^${key}=(.*)$`, "m"));
+  return match && match[1].trim() ? match[1].trim() : undefined;
+}
+
+function readStylusEnv(checkoutRoot) {
+  const envPath = path.join(checkoutRoot, "packages", "stylus", ".env");
+  const keys = ["ACCOUNT_ADDRESS_SEPOLIA", "RPC_URL_SEPOLIA", "PRIVATE_KEY_SEPOLIA"];
+  const out = {};
+  for (const key of keys) {
+    const value = readStylusEnvKey(envPath, key);
+    if (value) out[key] = value;
+  }
+  return out;
+}
+
+// Never printed, echoed, or logged -- same contract as cdp-with-wallet.
+function getKeychainPassword(service = "stylus-demo-metamask") {
+  return execFileSync("security", ["find-generic-password", "-s", service, "-w"], { encoding: "utf8" }).trim();
+}
+
+async function waitForHttpReady(url, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  let lastErr;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url);
+      if (res.status < 500) return true;
+    } catch (err) {
+      lastErr = err;
+    }
+    await sleep(500);
+  }
+  throw new Error(`${url} never became ready within ${timeoutMs}ms (last error: ${lastErr?.message})`);
+}
+
+async function waitFor(cdp, expression, timeoutMs, description = expression) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const ok = await evaluate(cdp, expression).catch(() => false);
+    if (ok) return true;
+    await sleep(300);
+  }
+  throw new Error(`Timed out after ${timeoutMs}ms waiting for: ${description}`);
+}
+
+// ---------------------------------------------------------------------------
+// Take 1 -- terminal: smoke-test Step 9 (9a-9e only; 9f is deferred to
+// cleanupAll()), recorded with asciinema. This is the ACTUAL deploy command,
+// not a replay -- if it drifts from Step 9 as documented, that is a bug in
+// this script, not an acceptable trade-off (see SKILL.md).
+// ---------------------------------------------------------------------------
+
+const STEP9_SCRIPT_PATH = path.join(HERE, "step9.sh");
+
+async function take1({ outDir, cwd, checkoutRoot }) {
+  const envVars = readStylusEnv(checkoutRoot);
+  const resultPath = path.join(os.tmpdir(), `demo-video-step9-result-${process.pid}.json`);
+
+  const castPath = path.join(outDir, "take1-terminal-sepolia-deploy.cast");
+  const gifPath = path.join(outDir, "take1-terminal-sepolia-deploy.gif");
+
+  console.log(`[take1] recording -> ${castPath}`);
+  const rec = spawnSync(
+    "asciinema",
+    ["record", "--command", `bash ${STEP9_SCRIPT_PATH}`, "--output-format", "asciicast-v3", "--return", "--overwrite", castPath],
+    {
+      cwd,
+      stdio: "inherit",
+      env: { ...process.env, ...envVars, DEMO_RESULT_FILE: resultPath },
+    },
+  );
+
+  let result;
+  try {
+    result = JSON.parse(fs.readFileSync(resultPath, "utf8"));
+  } catch {
+    result = { status: "FAIL", reason: `Step 9 script produced no result file (asciinema exit ${rec.status})`, address: null, txHash: null };
+  }
+  fs.rmSync(resultPath, { force: true });
+
+  if (!fs.existsSync(castPath) || fs.statSync(castPath).size < 100) {
+    throw new Error(`Take 1 recording missing or trivially small: ${castPath}`);
+  }
+  const castSize = fs.statSync(castPath).size;
+
+  let gifSize = null;
+  if (result.status === "PASS") {
+    console.log(`[take1] converting to GIF -> ${gifPath}`);
+    execFileSync("agg", [castPath, gifPath], { stdio: "inherit" });
+    gifSize = fs.statSync(gifPath).size;
+  } else {
+    console.log(`[take1] status=${result.status}, skipping GIF conversion`);
+  }
+
+  return { ...result, castPath, gifPath: gifSize ? gifPath : null, castSize, gifSize };
+}
+
+// ---------------------------------------------------------------------------
+// Take 2 -- browser: real MetaMask connect + write tx against the just-
+// deployed Sepolia contract, recorded via CDP Page.startScreencast.
+//
+// Why CDP screencast, not macOS `screencapture -v`: the original design used
+// screencapture, which requires the macOS Screen Recording TCC permission
+// for whichever app hosts the invoking process. That permission was granted
+// mid-build but had NOT taken effect (macOS only applies a TCC grant on
+// process restart, and the host app was not restarted) -- yet a probe
+// recording still succeeded (ffprobe-verified: real duration, real
+// dimensions, real frame count -- see SKILL.md). The user's own call, given
+// that ambiguity and the cost of a restart, was to switch to CDP's
+// Page.startScreencast instead: it captures frames from inside Chrome, needs
+// no OS permission, works headless, and works in CI. This is the approach
+// actually implemented below, not screencapture.
+//
+// THE TRAP: Page.screencastFrame does NOT fire at a fixed rate -- only when
+// the page repaints -- and each frame must be acked via
+// Page.screencastFrameAck or the stream stalls. Naively dumping frames to
+// disk and assembling at a fixed fps would compress long-idle periods and
+// stretch busy ones, producing a video whose timing has nothing to do with
+// what actually happened (a valid file that plays, but is silently wrong --
+// the same failure class as everything else flagged in this spec). The fix:
+// record each frame's own `metadata.timestamp` (seconds since epoch) and
+// assemble with ffmpeg's concat demuxer using a per-frame `duration` entry
+// computed from the gap to the NEXT frame's timestamp, not a fixed rate.
+// ---------------------------------------------------------------------------
+
+async function startScreencastCapture(cdp, framesDir, { format = "png", maxWidth = 1280, maxHeight = 800 } = {}) {
+  fs.mkdirSync(framesDir, { recursive: true });
+  const frames = [];
+  let idx = 0;
+  let stopped = false;
+  const ext = format === "jpeg" ? "jpg" : "png";
+  const unsubscribe = cdp.on("Page.screencastFrame", params => {
+    const { data, metadata, sessionId } = params;
+    const file = path.join(framesDir, `frame-${String(idx++).padStart(6, "0")}.${ext}`);
+    fs.writeFileSync(file, Buffer.from(data, "base64"));
+    frames.push({ file, timestamp: metadata.timestamp });
+    // Fire-and-forget ack -- if this throws (session already stopping), the
+    // stream is ending anyway; a missed ack there cannot lose a frame that
+    // matters.
+    cdp.send("Page.screencastFrameAck", { sessionId }).catch(() => {});
+  });
+  await cdp.send("Page.startScreencast", { format, maxWidth, maxHeight, everyNthFrame: 1 });
+  return {
+    async stop() {
+      if (stopped) return frames;
+      stopped = true;
+      await cdp.send("Page.stopScreencast").catch(() => {});
+      unsubscribe();
+      return frames;
+    },
+  };
+}
+
+function assembleVideo(frames, outPath, endTimestamp) {
+  if (frames.length === 0) throw new Error("No screencast frames captured -- nothing to assemble into a video");
+  const concatPath = `${outPath}.concat.txt`;
+  const lines = ["ffconcat version 1.0"];
+  for (let i = 0; i < frames.length; i++) {
+    const cur = frames[i];
+    const next = frames[i + 1];
+    const nextTs = next ? next.timestamp : endTimestamp;
+    const duration = Math.max(nextTs - cur.timestamp, 0.05);
+    lines.push(`file '${cur.file}'`);
+    lines.push(`duration ${duration.toFixed(3)}`);
+  }
+  // ffmpeg's concat demuxer ignores the duration on the FINAL entry unless a
+  // file directive follows it -- repeat the last frame's path with no
+  // duration line to make its preceding duration take effect.
+  lines.push(`file '${frames[frames.length - 1].file}'`);
+  fs.writeFileSync(concatPath, `${lines.join("\n")}\n`);
+
+  execFileSync("ffmpeg", ["-y", "-f", "concat", "-safe", "0", "-i", concatPath, "-vsync", "vfr", "-pix_fmt", "yuv420p", outPath], {
+    stdio: "inherit",
+  });
+  fs.rmSync(concatPath, { force: true });
+}
+
+function ffprobeDuration(videoPath) {
+  const out = execFileSync(
+    "ffprobe",
+    ["-v", "error", "-show_entries", "format=duration", "-of", "default=noprint_wrappers=1:nokey=1", videoPath],
+    { encoding: "utf8" },
+  ).trim();
+  return parseFloat(out);
+}
+
+async function tryScrapeTxHashLink(cdp) {
+  return evaluate(
+    cdp,
+    `(() => {
+      const a = Array.from(document.querySelectorAll('a[href*="/tx/0x"]'))[0];
+      return a ? a.href : null;
+    })()`,
+  ).catch(() => null);
+}
+
+async function take2({ outDir, cwd }) {
+  const configPath = path.join(cwd, "packages", "nextjs", "scaffold.config.ts");
+  const originalConfig = fs.readFileSync(configPath, "utf8");
+  const NITRO = "targetNetworks: [chains.arbitrumNitro]";
+  const SEPOLIA = "targetNetworks: [chains.arbitrumSepolia]";
+  if (!originalConfig.includes(NITRO)) {
+    throw new Error(`scaffold.config.ts: expected to find "${NITRO}" -- refusing to guess a replacement`);
+  }
+  fs.writeFileSync(configPath, originalConfig.replace(NITRO, SEPOLIA));
+  console.log(`[take2] scaffold.config.ts switched to arbitrumSepolia`);
+
+  const restoreConfig = () => fs.writeFileSync(configPath, originalConfig);
+
+  const frontendPort = await findFreePort(3000);
+  const frontendLogPath = path.join(outDir, "take2-frontend.log");
+  const frontendLogFd = fs.openSync(frontendLogPath, "a");
+  const frontend = spawn("yarn", ["workspace", "@ss/nextjs", "dev", "-p", String(frontendPort)], {
+    cwd,
+    stdio: ["ignore", frontendLogFd, frontendLogFd],
+    detached: true,
+  });
+  frontend.unref();
+  console.log(`[take2] frontend starting on :${frontendPort} (PID ${frontend.pid}), waiting for ready...`);
+
+  let chrome = null;
+  let disabledIds = [];
+  let dappWs = null;
+  const framesDir = path.join(outDir, ".take2-frames-tmp");
+
+  try {
+    await waitForHttpReady(`http://localhost:${frontendPort}`, 90000);
+    console.log(`[take2] frontend ready`);
+
+    const password = getKeychainPassword();
+    const cdpPort = await findFreePort(9222);
+    chrome = launchChrome({ port: cdpPort, userDataDir: path.join(os.homedir(), ".chrome-debug-profile"), headless: true });
+    console.log(`[take2] Chrome launched headless, PID ${chrome.pid}, CDP port ${cdpPort}`);
+    await waitForCdpReady(cdpPort);
+    ({ disabledIds } = await isolateExtensions(cdpPort, METAMASK_EXTENSION_ID, chrome.pid));
+    console.log(`[take2] isolated ${disabledIds.length} other extension(s)`);
+
+    await unlock({ port: cdpPort, extensionId: METAMASK_EXTENSION_ID, password });
+    console.log(`[take2] MetaMask unlocked`);
+
+    const tabRes = await fetch(`http://127.0.0.1:${cdpPort}/json/new?${encodeURIComponent(`http://localhost:${frontendPort}/debug`)}`, {
+      method: "PUT",
+    });
+    const tab = await tabRes.json();
+    dappWs = new WebSocket(tab.webSocketDebuggerUrl);
+    await new Promise((resolve, reject) => {
+      dappWs.addEventListener("open", () => resolve(), { once: true });
+      dappWs.addEventListener("error", err => reject(new Error(`dapp WebSocket connect failed: ${err.message}`)), { once: true });
+    });
+    const dappCdp = new CDP(dappWs);
+    await dappCdp.send("Runtime.enable");
+    await dappCdp.send("Page.enable");
+    await dappCdp.send("Emulation.setDeviceMetricsOverride", { width: 1280, height: 800, deviceScaleFactor: 1, mobile: false });
+
+    await waitFor(dappCdp, `!!document.querySelector('[data-testid="write-function-form-setGreeting"]')`, 30000, "debug page's setGreeting form rendered");
+    console.log(`[take2] /debug page rendered`);
+
+    const capture = await startScreencastCapture(dappCdp, framesDir, { format: "png", maxWidth: 1280, maxHeight: 800 });
+    const wallStart = Date.now();
+    console.log(`[take2] screencast started`);
+
+    const alreadyConnected = await evaluate(dappCdp, `!document.querySelector('[data-testid="connect-wallet"]')`);
+    if (!alreadyConnected) {
+      const { accounts } = await connect({ port: cdpPort, extensionId: METAMASK_EXTENSION_ID, dappCdp });
+      if (!accounts?.length) throw new Error("connect() returned no accounts");
+      console.log(`[take2] connected: ${accounts[0]}`);
+    } else {
+      console.log(`[take2] already connected`);
+    }
+
+    await waitFor(dappCdp, `!document.querySelector('[data-testid="connect-wallet"]')`, 20000, "UI reflects connected state (connect-wallet button gone)");
+
+    // MEASURED (2026-07-22): a fresh connect() only gets accounts -- it does
+    // NOT put MetaMask on Arbitrum Sepolia. The debug profile's MetaMask
+    // instance was left on whatever chain a prior session used (observed:
+    // 0x1, mainnet) and the dapp rendered its "Wrong network" banner with
+    // write-function-submit disabled, even though accounts were connected.
+    // wallet_addEthereumChain, called the same way connect() discovers the
+    // EIP-6963 provider, both adds (if missing) AND switches -- MEASURED: on
+    // an already-added chain (this profile added 0x66eee during
+    // cdp-with-wallet's own onboarding proof) it resolved with NO
+    // confirmation popup at all, silently switching; approveTx() is still
+    // raced defensively below in case a popup DOES appear (e.g. a chain not
+    // yet added, or a not-yet-trusted origin), matching SKILL.md's
+    // documented add-network flow.
+    const switchResult = await evaluate(
+      dappCdp,
+      `(async () => {
+        const providers = [];
+        function onAnnounce(event) { providers.push(event.detail); }
+        window.addEventListener("eip6963:announceProvider", onAnnounce);
+        window.dispatchEvent(new Event("eip6963:requestProvider"));
+        await new Promise(r => setTimeout(r, 500));
+        window.removeEventListener("eip6963:announceProvider", onAnnounce);
+        const match = providers.find(p => p.info?.rdns === "io.metamask");
+        if (!match) return { error: "no EIP-6963 provider announced rdns=io.metamask" };
+        try {
+          await match.provider.request({ method: "wallet_addEthereumChain", params: [{
+            chainId: "0x66eee",
+            chainName: "Arbitrum Sepolia",
+            nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+            rpcUrls: ["https://sepolia-rollup.arbitrum.io/rpc"],
+            blockExplorerUrls: ["https://sepolia.arbiscan.io"],
+          }] });
+          return { switched: true };
+        } catch (e) {
+          return { error: e.message };
+        }
+      })()`,
+    );
+    if (switchResult?.error) throw new Error(`wallet_addEthereumChain failed: ${switchResult.error}`);
+    console.log(`[take2] network switch result: ${JSON.stringify(switchResult)}`);
+    // Best-effort: a popup only appears for a not-yet-trusted chain/origin.
+    await approveTx({ port: cdpPort, extensionId: METAMASK_EXTENSION_ID, timeoutMs: 3000 }).catch(() => {});
+
+    await waitFor(
+      dappCdp,
+      `!document.querySelector('[data-testid="write-function-submit"]')?.disabled`,
+      20000,
+      "UI reflects correct network (write-function-submit enabled)",
+    );
+
+    const newGreeting = `demo-video ${new Date().toISOString()}`;
+    await evaluate(
+      dappCdp,
+      `(() => {
+        const form = document.querySelector('[data-testid="write-function-form-setGreeting"]');
+        const input = form.querySelector('[data-testid="function-input"]');
+        input.focus();
+        return document.activeElement === input;
+      })()`,
+    );
+    // Input.insertText, not input.value = x -- React shadows the native
+    // setter (see browser-e2e.mjs's own Common Mistakes section); this is
+    // the same technique metamask.mjs uses for the exact same reason.
+    await dappCdp.send("Input.insertText", { text: newGreeting });
+    const clicked = await evaluate(
+      dappCdp,
+      `(() => {
+        const form = document.querySelector('[data-testid="write-function-form-setGreeting"]');
+        const btn = form.querySelector('[data-testid="write-function-submit"]');
+        if (!btn || btn.disabled) return false;
+        btn.click();
+        return true;
+      })()`,
+    );
+    if (!clicked) throw new Error("Could not click write-function-submit");
+    console.log(`[take2] submitted setGreeting("${newGreeting}")`);
+
+    await approveTx({ port: cdpPort, extensionId: METAMASK_EXTENSION_ID });
+    console.log(`[take2] approved transaction in MetaMask`);
+
+    const expected = JSON.stringify(newGreeting); // displayed value is JSON.stringify()'d, per browser-e2e.mjs precedent
+    let txLink = null;
+    const deadline = Date.now() + 60000;
+    let readBack = false;
+    while (Date.now() < deadline) {
+      if (!txLink) txLink = await tryScrapeTxHashLink(dappCdp);
+      const val = await evaluate(
+        dappCdp,
+        `document.querySelector('[data-testid="display-variable-greeting"] [data-testid="display-variable-value"]')?.textContent || ""`,
+      ).catch(() => "");
+      if (val === expected) {
+        readBack = true;
+        break;
+      }
+      await sleep(400);
+    }
+    if (!readBack) throw new Error(`Timed out waiting for greeting() read-back to equal ${expected}`);
+    console.log(`[take2] read-back confirmed: greeting() == ${newGreeting}`);
+
+    await sleep(1500); // let the final state settle on screen before stopping
+    const frames = await capture.stop();
+    const wallEnd = Date.now();
+    console.log(`[take2] screencast stopped, ${frames.length} frame(s) captured`);
+
+    const videoPath = path.join(outDir, "take2-browser-wallet-tx.mp4");
+    assembleVideo(frames, videoPath, frames.length ? wallEnd / 1000 : 0);
+    fs.rmSync(framesDir, { recursive: true, force: true });
+
+    const videoDurationSeconds = ffprobeDuration(videoPath);
+    const wallClockSeconds = (wallEnd - wallStart) / 1000;
+
+    return {
+      status: "PASS",
+      newGreeting,
+      txLink,
+      videoPath,
+      videoSize: fs.statSync(videoPath).size,
+      videoDurationSeconds,
+      wallClockSeconds,
+      frameCount: frames.length,
+    };
+  } finally {
+    if (chrome) {
+      const cdpPortForTeardown = chrome.port;
+      await restoreExtensions(cdpPortForTeardown, disabledIds, chrome.pid).catch(err => console.error(`[take2] restoreExtensions failed: ${err.message}`));
+      await killChromeGroup(chrome.pid).catch(err => console.error(`[take2] killChromeGroup failed: ${err.message}`));
+    }
+    if (dappWs) {
+      try {
+        dappWs.close();
+      } catch {
+        /* already closed */
+      }
+    }
+    try {
+      process.kill(-frontend.pid, "SIGTERM");
+    } catch {
+      /* already gone */
+    }
+    fs.rmSync(framesDir, { recursive: true, force: true });
+    restoreConfig();
+    console.log(`[take2] scaffold.config.ts restored, frontend (PID ${frontend.pid}) signaled to stop`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup -- the Step 9f equivalent, deferred until after Take 2 (see the
+// sequencing note at the top of this file). Safe to call standalone as an
+// escape hatch after a crashed run.
+//
+// packages/nextjs/next-env.d.ts may ALREADY be dirty before this skill ever
+// runs (Next.js rewrites it on its own); a blind `git checkout --` on it
+// would silently discard a developer's pre-existing, unrelated change. Only
+// restore files that were clean at baseline and became dirty during this
+// run -- baselineDirty is captured once in main(), before take1/take2 run.
+// ---------------------------------------------------------------------------
+function isDirty(cwd, relPath) {
+  return spawnSync("git", ["diff", "--quiet", "--", relPath], { cwd }).status !== 0;
+}
+
+function cleanupAll({ cwd, baselineDirty }) {
+  console.log(`[cleanup] restoring packages/nextjs/contracts/deployedContracts.ts (Step 9f)`);
+  spawnSync("git", ["checkout", "--", "packages/nextjs/contracts/deployedContracts.ts"], { cwd, stdio: "inherit" });
+
+  for (const relPath of ["packages/nextjs/scaffold.config.ts", "packages/nextjs/next-env.d.ts"]) {
+    const wasBaselineDirty = baselineDirty?.[relPath] ?? false;
+    if (!wasBaselineDirty && isDirty(cwd, relPath)) {
+      console.log(`[cleanup] restoring ${relPath} (was clean before this run)`);
+      spawnSync("git", ["checkout", "--", relPath], { cwd, stdio: "inherit" });
+    } else if (wasBaselineDirty) {
+      console.log(`[cleanup] leaving ${relPath} alone -- already dirty before this run started`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+async function main() {
+  const cwd = worktreeRoot();
+  const checkoutRoot = mainCheckoutRoot();
+  const dateStr = new Date().toISOString().slice(0, 10);
+  const outDir = process.env.DEMO_VIDEO_OUTDIR || path.join(os.homedir(), "Desktop", `stylus-demo-${dateStr}`);
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const mode = process.argv[2] || "all";
+  const report = { mode, outDir };
+
+  const baselineDirty = {
+    "packages/nextjs/scaffold.config.ts": isDirty(cwd, "packages/nextjs/scaffold.config.ts"),
+    "packages/nextjs/next-env.d.ts": isDirty(cwd, "packages/nextjs/next-env.d.ts"),
+  };
+
+  try {
+    if (mode === "take1" || mode === "all") {
+      report.take1 = await take1({ outDir, cwd, checkoutRoot });
+      console.log(`[main] take1: ${JSON.stringify(report.take1, null, 2)}`);
+      if (mode === "all" && report.take1.status !== "PASS") {
+        console.log(`[main] take1 status=${report.take1.status}, skipping take2 (nothing deployed to show)`);
+      }
+    }
+    if (mode === "take2" || (mode === "all" && report.take1?.status === "PASS")) {
+      report.take2 = await take2({ outDir, cwd });
+      console.log(`[main] take2: ${JSON.stringify(report.take2, null, 2)}`);
+    }
+  } finally {
+    if (mode === "all" || mode === "cleanup") {
+      cleanupAll({ cwd, baselineDirty });
+    }
+  }
+
+  console.log(`\n=== FINAL REPORT ===`);
+  console.log(JSON.stringify(report, null, 2));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch(err => {
+    console.error(`FATAL: ${err.stack || err.message}`);
+    process.exit(1);
+  });
+}

--- a/.claude/skills/demo-video/record.mjs
+++ b/.claude/skills/demo-video/record.mjs
@@ -20,17 +20,27 @@
 // and .claude/skills/cdp-with-wallet/*.mjs.
 //
 // Usage:
-//   node record.mjs all        -- take1, then take2, then cleanup (default)
-//   node record.mjs take1      -- terminal take only (no cleanup -- leaves
-//                                  deployedContracts.ts with the Sepolia
-//                                  entry on purpose, for a manual take2)
-//   node record.mjs take2      -- browser take only (assumes take1 already
-//                                  ran and deployedContracts.ts has the
-//                                  Sepolia entry)
+//   node record.mjs all --branch=<name> [--pr=<number>]
+//                              -- take1, then take2, then cleanup (default)
+//   node record.mjs take1 --branch=<name>
+//                              -- terminal take only (no cleanup -- leaves
+//                                 deployedContracts.ts with the Sepolia
+//                                 entry on purpose, for a manual take2)
+//   node record.mjs take2 --branch=<name>
+//                              -- browser take only (assumes take1 already
+//                                 ran and deployedContracts.ts has the
+//                                 Sepolia entry)
 //   node record.mjs cleanup    -- restore scaffold.config.ts /
-//                                  deployedContracts.ts, kill any leaked
-//                                  frontend/Chrome -- the escape hatch if a
-//                                  run crashed mid-flight
+//                                 deployedContracts.ts, kill any leaked
+//                                 frontend/Chrome -- the escape hatch if a
+//                                 run crashed mid-flight
+//
+// --branch is REQUIRED for all/take1/take2 (see requireStatedBranch() below
+// for why: a demo recorded from the wrong branch looks completely valid and
+// is silently worthless -- this cost a full recording cycle on 2026-07-22,
+// see SKILL.md). DEMO_VIDEO_BRANCH env var works the same as --branch.
+// --pr=<number> lets the proof block (see buildProofBlock()) get posted as
+// a PR comment automatically; without it, the block is only printed.
 
 import { execFileSync, spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
@@ -74,6 +84,60 @@ function mainCheckoutRoot() {
 
 function worktreeRoot() {
   return execFileSync("git", ["rev-parse", "--show-toplevel"], { cwd: process.cwd(), encoding: "utf8" }).trim();
+}
+
+function parseCliFlag(name) {
+  const prefix = `--${name}=`;
+  const arg = process.argv.find(a => a.startsWith(prefix));
+  return arg ? arg.slice(prefix.length) : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Base-branch preflight -- THE LESSON from 2026-07-22: this skill was built
+// and run without ever stating which branch it was recording from. Take 2
+// was recorded from `main`, which still had the Uniswap price-fetch feature
+// and none of the ENS/pagination fixes that had already landed on
+// release/phase-1 -- a fully valid-looking, watchable video that quietly
+// proved the wrong code. A demo video is only worth anything if it's
+// unambiguous what it was recorded from, and a script cannot infer intent
+// from `git branch --show-current` alone (that only says what happens to be
+// checked out, not what the operator MEANT to demo). So: refuse to record
+// at all until the target branch is stated explicitly (--branch=<name> or
+// DEMO_VIDEO_BRANCH), and require it to match what's actually checked out --
+// catching the second-order mistake of stating one branch while sitting on
+// another. Same SKIP-not-fail contract as smoke-test's other gates.
+// ---------------------------------------------------------------------------
+function requireStatedBranch(cwd) {
+  const actualBranch = execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd, encoding: "utf8" }).trim();
+  const sha = execFileSync("git", ["rev-parse", "HEAD"], { cwd, encoding: "utf8" }).trim();
+  const subject = execFileSync("git", ["log", "-1", "--format=%s"], { cwd, encoding: "utf8" }).trim();
+
+  const stated = parseCliFlag("branch") || process.env.DEMO_VIDEO_BRANCH;
+  if (!stated) {
+    console.error(
+      `SKIPPED -- no target branch stated.\n` +
+        `This skill refuses to record until you say which branch you mean to demo\n` +
+        `(a recording from the wrong branch looks completely valid and is silently\n` +
+        `worthless -- see SKILL.md).\n\n` +
+        `Currently checked out: ${actualBranch} @ ${sha.slice(0, 7)} (${subject})\n\n` +
+        `Re-run with: --branch=${actualBranch}   (or set DEMO_VIDEO_BRANCH=${actualBranch})\n` +
+        `if that IS the branch you mean to demo, or check out the right one first.`,
+    );
+    process.exit(3);
+  }
+  if (stated !== actualBranch) {
+    console.error(
+      `SKIPPED -- stated branch does not match what's checked out.\n` +
+        `  stated:        ${stated}\n` +
+        `  checked out:   ${actualBranch} @ ${sha.slice(0, 7)} (${subject})\n` +
+        `Check out '${stated}' first, or re-run with --branch=${actualBranch} if that's what you actually mean to demo.`,
+    );
+    process.exit(3);
+  }
+
+  const source = { branch: actualBranch, sha, shortSha: sha.slice(0, 7), subject };
+  console.log(`Recording from branch '${source.branch}' @ ${source.shortSha} (${source.subject})`);
+  return source;
 }
 
 // Regex-per-key extraction, matching preflight.mjs's own style -- no dotenv
@@ -136,17 +200,29 @@ async function waitFor(cdp, expression, timeoutMs, description = expression) {
 
 const STEP9_SCRIPT_PATH = path.join(HERE, "step9.sh");
 
-async function take1({ outDir, cwd, checkoutRoot }) {
+async function take1({ outDir, cwd, checkoutRoot, recordingSource }) {
   const envVars = readStylusEnv(checkoutRoot);
   const resultPath = path.join(os.tmpdir(), `demo-video-step9-result-${process.pid}.json`);
 
   const castPath = path.join(outDir, "take1-terminal-sepolia-deploy.cast");
   const gifPath = path.join(outDir, "take1-terminal-sepolia-deploy.gif");
+  const title = `demo-video take1 -- ${recordingSource.branch}@${recordingSource.shortSha}`;
 
   console.log(`[take1] recording -> ${castPath}`);
   const rec = spawnSync(
     "asciinema",
-    ["record", "--command", `bash ${STEP9_SCRIPT_PATH}`, "--output-format", "asciicast-v3", "--return", "--overwrite", castPath],
+    [
+      "record",
+      "--command",
+      `bash ${STEP9_SCRIPT_PATH}`,
+      "--output-format",
+      "asciicast-v3",
+      "--title",
+      title,
+      "--return",
+      "--overwrite",
+      castPath,
+    ],
     {
       cwd,
       stdio: "inherit",
@@ -172,6 +248,29 @@ async function take1({ outDir, cwd, checkoutRoot }) {
     console.log(`[take1] converting to GIF -> ${gifPath}`);
     execFileSync("agg", [castPath, gifPath], { stdio: "inherit" });
     gifSize = fs.statSync(gifPath).size;
+
+    // demo-video's OWN staleness exposure, distinct from step9.sh's: Take 2
+    // reads packages/nextjs/contracts/deployedContracts.ts to decide what
+    // the frontend shows, not the deployments/*.json step9.sh already
+    // cross-checked. deploy_contract.ts writes both files in the same
+    // invocation, but only as two separate steps (deploy, then a SEPARATE
+    // export-abi + write-deployedContracts.ts step) -- if the second step
+    // silently no-ops while the first succeeds, deployedContracts.ts could
+    // still hold a stale address from a previous run even though
+    // deployments/421614_latest.json (and step9.sh's cross-check of it) is
+    // genuinely fresh. Confirm the address Take 2 will actually render
+    // matches the address this run just deployed, before calling it PASS.
+    const deployedContractsPath = path.join(cwd, "packages", "nextjs", "contracts", "deployedContracts.ts");
+    const deployedContractsText = fs.readFileSync(deployedContractsPath, "utf8");
+    if (!result.address || !deployedContractsText.includes(result.address)) {
+      console.error(
+        `[take1] FAIL -- deployedContracts.ts does not contain this run's deployed address (${result.address}); ` +
+          `Take 2 would render a stale contract. Not treating this as PASS.`,
+      );
+      result = { ...result, status: "FAIL", reason: "deployedContracts.ts stale relative to this run's deploy" };
+    } else {
+      console.log(`[take1] deployedContracts.ts cross-checked against this run's address (${result.address})`);
+    }
   } else {
     console.log(`[take1] status=${result.status}, skipping GIF conversion`);
   }
@@ -235,7 +334,7 @@ async function startScreencastCapture(cdp, framesDir, { format = "png", maxWidth
   };
 }
 
-function assembleVideo(frames, outPath, endTimestamp) {
+function assembleVideo(frames, outPath, endTimestamp, recordingSource) {
   if (frames.length === 0) throw new Error("No screencast frames captured -- nothing to assemble into a video");
   const concatPath = `${outPath}.concat.txt`;
   const lines = ["ffconcat version 1.0"];
@@ -262,9 +361,27 @@ function assembleVideo(frames, outPath, endTimestamp) {
   lines.push(`file '${frames[frames.length - 1].file}'`);
   fs.writeFileSync(concatPath, `${lines.join("\n")}\n`);
 
-  execFileSync("ffmpeg", ["-y", "-f", "concat", "-safe", "0", "-i", concatPath, "-vsync", "vfr", "-pix_fmt", "yuv420p", outPath], {
-    stdio: "inherit",
-  });
+  const comment = `demo-video take2 -- recorded from ${recordingSource.branch}@${recordingSource.shortSha} (${recordingSource.subject})`;
+  execFileSync(
+    "ffmpeg",
+    [
+      "-y",
+      "-f",
+      "concat",
+      "-safe",
+      "0",
+      "-i",
+      concatPath,
+      "-vsync",
+      "vfr",
+      "-pix_fmt",
+      "yuv420p",
+      "-metadata",
+      `comment=${comment}`,
+      outPath,
+    ],
+    { stdio: "inherit" },
+  );
   fs.rmSync(concatPath, { force: true });
 }
 
@@ -287,7 +404,7 @@ async function tryScrapeTxHashLink(cdp) {
   ).catch(() => null);
 }
 
-async function take2({ outDir, cwd }) {
+async function take2({ outDir, cwd, checkoutRoot, contractAddress, recordingSource }) {
   const configPath = path.join(cwd, "packages", "nextjs", "scaffold.config.ts");
   const originalConfig = fs.readFileSync(configPath, "utf8");
   const NITRO = "targetNetworks: [chains.arbitrumNitro]";
@@ -352,138 +469,192 @@ async function take2({ outDir, cwd }) {
     const wallStart = Date.now();
     console.log(`[take2] screencast started`);
 
-    const alreadyConnected = await evaluate(dappCdp, `!document.querySelector('[data-testid="connect-wallet"]')`);
-    if (!alreadyConnected) {
-      const { accounts } = await connect({ port: cdpPort, extensionId: METAMASK_EXTENSION_ID, dappCdp });
-      if (!accounts?.length) throw new Error("connect() returned no accounts");
-      console.log(`[take2] connected: ${accounts[0]}`);
-    } else {
-      console.log(`[take2] already connected`);
-    }
-
-    await waitFor(dappCdp, `!document.querySelector('[data-testid="connect-wallet"]')`, 20000, "UI reflects connected state (connect-wallet button gone)");
-
-    // MEASURED (2026-07-22): a fresh connect() only gets accounts -- it does
-    // NOT put MetaMask on Arbitrum Sepolia. The debug profile's MetaMask
-    // instance was left on whatever chain a prior session used (observed:
-    // 0x1, mainnet) and the dapp rendered its "Wrong network" banner with
-    // write-function-submit disabled, even though accounts were connected.
-    // wallet_addEthereumChain, called the same way connect() discovers the
-    // EIP-6963 provider, both adds (if missing) AND switches -- MEASURED: on
-    // an already-added chain (this profile added 0x66eee during
-    // cdp-with-wallet's own onboarding proof) it resolved with NO
-    // confirmation popup at all, silently switching; approveTx() is still
-    // raced defensively below in case a popup DOES appear (e.g. a chain not
-    // yet added, or a not-yet-trusted origin), matching SKILL.md's
-    // documented add-network flow.
-    const switchResult = await evaluate(
-      dappCdp,
-      `(async () => {
-        const providers = [];
-        function onAnnounce(event) { providers.push(event.detail); }
-        window.addEventListener("eip6963:announceProvider", onAnnounce);
-        window.dispatchEvent(new Event("eip6963:requestProvider"));
-        await new Promise(r => setTimeout(r, 500));
-        window.removeEventListener("eip6963:announceProvider", onAnnounce);
-        const match = providers.find(p => p.info?.rdns === "io.metamask");
-        if (!match) return { error: "no EIP-6963 provider announced rdns=io.metamask" };
-        try {
-          await match.provider.request({ method: "wallet_addEthereumChain", params: [{
-            chainId: "0x66eee",
-            chainName: "Arbitrum Sepolia",
-            nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
-            rpcUrls: ["https://sepolia-rollup.arbitrum.io/rpc"],
-            blockExplorerUrls: ["https://sepolia.arbiscan.io"],
-          }] });
-          return { switched: true };
-        } catch (e) {
-          return { error: e.message };
-        }
-      })()`,
-    );
-    if (switchResult?.error) throw new Error(`wallet_addEthereumChain failed: ${switchResult.error}`);
-    console.log(`[take2] network switch result: ${JSON.stringify(switchResult)}`);
-    // Best-effort: a popup only appears for a not-yet-trusted chain/origin.
-    await approveTx({ port: cdpPort, extensionId: METAMASK_EXTENSION_ID, timeoutMs: 3000 }).catch(() => {});
-
-    await waitFor(
-      dappCdp,
-      `!document.querySelector('[data-testid="write-function-submit"]')?.disabled`,
-      20000,
-      "UI reflects correct network (write-function-submit enabled)",
-    );
-
-    const newGreeting = `demo-video ${new Date().toISOString()}`;
-    await evaluate(
-      dappCdp,
-      `(() => {
-        const form = document.querySelector('[data-testid="write-function-form-setGreeting"]');
-        const input = form.querySelector('[data-testid="function-input"]');
-        input.focus();
-        return document.activeElement === input;
-      })()`,
-    );
-    // Input.insertText, not input.value = x -- React shadows the native
-    // setter (see browser-e2e.mjs's own Common Mistakes section); this is
-    // the same technique metamask.mjs uses for the exact same reason.
-    await dappCdp.send("Input.insertText", { text: newGreeting });
-    const clicked = await evaluate(
-      dappCdp,
-      `(() => {
-        const form = document.querySelector('[data-testid="write-function-form-setGreeting"]');
-        const btn = form.querySelector('[data-testid="write-function-submit"]');
-        if (!btn || btn.disabled) return false;
-        btn.click();
-        return true;
-      })()`,
-    );
-    if (!clicked) throw new Error("Could not click write-function-submit");
-    console.log(`[take2] submitted setGreeting("${newGreeting}")`);
-
-    await approveTx({ port: cdpPort, extensionId: METAMASK_EXTENSION_ID });
-    console.log(`[take2] approved transaction in MetaMask`);
-
-    const expected = JSON.stringify(newGreeting); // displayed value is JSON.stringify()'d, per browser-e2e.mjs precedent
-    let txLink = null;
-    const deadline = Date.now() + 60000;
-    let readBack = false;
-    while (Date.now() < deadline) {
-      if (!txLink) txLink = await tryScrapeTxHashLink(dappCdp);
-      const val = await evaluate(
-        dappCdp,
-        `document.querySelector('[data-testid="display-variable-greeting"] [data-testid="display-variable-value"]')?.textContent || ""`,
-      ).catch(() => "");
-      if (val === expected) {
-        readBack = true;
-        break;
+    // From here on, ANY failure still gets whatever frames were captured
+    // assembled and saved -- a partial recording someone can look at and
+    // say "it stops here, that's the bug" beats a clean failure with zero
+    // artifact. Only the setup above (frontend/Chrome/unlock, before there
+    // is anything on screen worth keeping) has no such fallback.
+    try {
+      const alreadyConnected = await evaluate(dappCdp, `!document.querySelector('[data-testid="connect-wallet"]')`);
+      if (!alreadyConnected) {
+        const { accounts } = await connect({ port: cdpPort, extensionId: METAMASK_EXTENSION_ID, dappCdp });
+        if (!accounts?.length) throw new Error("connect() returned no accounts");
+        console.log(`[take2] connected: ${accounts[0]}`);
+      } else {
+        console.log(`[take2] already connected`);
       }
-      await sleep(400);
+
+      await waitFor(dappCdp, `!document.querySelector('[data-testid="connect-wallet"]')`, 20000, "UI reflects connected state (connect-wallet button gone)");
+
+      // MEASURED (2026-07-22): a fresh connect() only gets accounts -- it does
+      // NOT put MetaMask on Arbitrum Sepolia. The debug profile's MetaMask
+      // instance was left on whatever chain a prior session used (observed:
+      // 0x1, mainnet) and the dapp rendered its "Wrong network" banner with
+      // write-function-submit disabled, even though accounts were connected.
+      // wallet_addEthereumChain, called the same way connect() discovers the
+      // EIP-6963 provider, both adds (if missing) AND switches -- MEASURED: on
+      // an already-added chain (this profile added 0x66eee during
+      // cdp-with-wallet's own onboarding proof) it resolved with NO
+      // confirmation popup at all, silently switching; approveTx() is still
+      // raced defensively below in case a popup DOES appear (e.g. a chain not
+      // yet added, or a not-yet-trusted origin), matching SKILL.md's
+      // documented add-network flow.
+      const switchResult = await evaluate(
+        dappCdp,
+        `(async () => {
+          const providers = [];
+          function onAnnounce(event) { providers.push(event.detail); }
+          window.addEventListener("eip6963:announceProvider", onAnnounce);
+          window.dispatchEvent(new Event("eip6963:requestProvider"));
+          await new Promise(r => setTimeout(r, 500));
+          window.removeEventListener("eip6963:announceProvider", onAnnounce);
+          const match = providers.find(p => p.info?.rdns === "io.metamask");
+          if (!match) return { error: "no EIP-6963 provider announced rdns=io.metamask" };
+          try {
+            await match.provider.request({ method: "wallet_addEthereumChain", params: [{
+              chainId: "0x66eee",
+              chainName: "Arbitrum Sepolia",
+              nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+              rpcUrls: ["https://sepolia-rollup.arbitrum.io/rpc"],
+              blockExplorerUrls: ["https://sepolia.arbiscan.io"],
+            }] });
+            return { switched: true };
+          } catch (e) {
+            return { error: e.message };
+          }
+        })()`,
+      );
+      if (switchResult?.error) throw new Error(`wallet_addEthereumChain failed: ${switchResult.error}`);
+      console.log(`[take2] network switch result: ${JSON.stringify(switchResult)}`);
+      // Best-effort: a popup only appears for a not-yet-trusted chain/origin.
+      await approveTx({ port: cdpPort, extensionId: METAMASK_EXTENSION_ID, timeoutMs: 3000 }).catch(() => {});
+
+      await waitFor(
+        dappCdp,
+        `!document.querySelector('[data-testid="write-function-submit"]')?.disabled`,
+        20000,
+        "UI reflects correct network (write-function-submit enabled)",
+      );
+
+      const newGreeting = `demo-video ${new Date().toISOString()}`;
+      await evaluate(
+        dappCdp,
+        `(() => {
+          const form = document.querySelector('[data-testid="write-function-form-setGreeting"]');
+          const input = form.querySelector('[data-testid="function-input"]');
+          input.focus();
+          return document.activeElement === input;
+        })()`,
+      );
+      // Input.insertText, not input.value = x -- React shadows the native
+      // setter (see browser-e2e.mjs's own Common Mistakes section); this is
+      // the same technique metamask.mjs uses for the exact same reason.
+      await dappCdp.send("Input.insertText", { text: newGreeting });
+      const clicked = await evaluate(
+        dappCdp,
+        `(() => {
+          const form = document.querySelector('[data-testid="write-function-form-setGreeting"]');
+          const btn = form.querySelector('[data-testid="write-function-submit"]');
+          if (!btn || btn.disabled) return false;
+          btn.click();
+          return true;
+        })()`,
+      );
+      if (!clicked) throw new Error("Could not click write-function-submit");
+      console.log(`[take2] submitted setGreeting("${newGreeting}")`);
+
+      await approveTx({ port: cdpPort, extensionId: METAMASK_EXTENSION_ID });
+      console.log(`[take2] approved transaction in MetaMask`);
+
+      const expected = JSON.stringify(newGreeting); // displayed value is JSON.stringify()'d, per browser-e2e.mjs precedent
+      let txLink = null;
+      const deadline = Date.now() + 60000;
+      let readBack = false;
+      while (Date.now() < deadline) {
+        if (!txLink) txLink = await tryScrapeTxHashLink(dappCdp);
+        const val = await evaluate(
+          dappCdp,
+          `document.querySelector('[data-testid="display-variable-greeting"] [data-testid="display-variable-value"]')?.textContent || ""`,
+        ).catch(() => "");
+        if (val === expected) {
+          readBack = true;
+          break;
+        }
+        await sleep(400);
+      }
+      if (!readBack) throw new Error(`Timed out waiting for greeting() read-back to equal ${expected}`);
+      console.log(`[take2] read-back confirmed: greeting() == ${newGreeting}`);
+
+      // Independent on-chain read-back -- not just the dapp's own UI reading
+      // its own write back to itself, but a fresh `cast call` against the RPC,
+      // the same proof shape Step 9e uses. This is what makes the video a
+      // claim a reviewer can check, not just a recording of the UI agreeing
+      // with itself (see SKILL.md "Why the proof block exists").
+      let onChainReadBack = null;
+      if (contractAddress) {
+        const { RPC_URL_SEPOLIA } = readStylusEnv(checkoutRoot);
+        if (RPC_URL_SEPOLIA) {
+          try {
+            onChainReadBack = execFileSync(
+              "cast",
+              ["call", contractAddress, "greeting()(string)", "--rpc-url", RPC_URL_SEPOLIA],
+              { encoding: "utf8" },
+            ).trim();
+            console.log(`[take2] independent on-chain read-back: ${onChainReadBack}`);
+          } catch (err) {
+            console.error(`[take2] independent on-chain read-back failed (non-fatal): ${err.message}`);
+          }
+        }
+      }
+
+      await sleep(1500); // let the final state settle on screen before stopping
+      const frames = await capture.stop();
+      const wallEnd = Date.now();
+      console.log(`[take2] screencast stopped, ${frames.length} frame(s) captured`);
+
+      const videoPath = path.join(outDir, "take2-browser-wallet-tx.mp4");
+      assembleVideo(frames, videoPath, frames.length ? wallEnd / 1000 : 0, recordingSource);
+      fs.rmSync(framesDir, { recursive: true, force: true });
+
+      const videoDurationSeconds = ffprobeDuration(videoPath);
+      const wallClockSeconds = (wallEnd - wallStart) / 1000;
+
+      return {
+        status: "PASS",
+        newGreeting,
+        txLink,
+        onChainReadBack,
+        videoPath,
+        videoSize: fs.statSync(videoPath).size,
+        videoDurationSeconds,
+        wallClockSeconds,
+        frameCount: frames.length,
+      };
+    } catch (err) {
+      const frames = await capture.stop().catch(() => []);
+      if (frames.length > 0) {
+        try {
+          const videoPath = path.join(outDir, "take2-browser-wallet-tx.mp4");
+          assembleVideo(frames, videoPath, Date.now() / 1000, recordingSource);
+          fs.rmSync(framesDir, { recursive: true, force: true });
+          const videoDurationSeconds = ffprobeDuration(videoPath);
+          console.error(`[take2] FAILED after capturing ${frames.length} frame(s) -- partial video saved: ${videoPath}`);
+          console.error(`[take2] failure: ${err.message}`);
+          return {
+            status: "FAIL",
+            error: err.message,
+            partial: true,
+            videoPath,
+            videoSize: fs.statSync(videoPath).size,
+            videoDurationSeconds,
+            frameCount: frames.length,
+          };
+        } catch (assembleErr) {
+          console.error(`[take2] could not assemble partial video either: ${assembleErr.message}`);
+        }
+      }
+      throw err;
     }
-    if (!readBack) throw new Error(`Timed out waiting for greeting() read-back to equal ${expected}`);
-    console.log(`[take2] read-back confirmed: greeting() == ${newGreeting}`);
-
-    await sleep(1500); // let the final state settle on screen before stopping
-    const frames = await capture.stop();
-    const wallEnd = Date.now();
-    console.log(`[take2] screencast stopped, ${frames.length} frame(s) captured`);
-
-    const videoPath = path.join(outDir, "take2-browser-wallet-tx.mp4");
-    assembleVideo(frames, videoPath, frames.length ? wallEnd / 1000 : 0);
-    fs.rmSync(framesDir, { recursive: true, force: true });
-
-    const videoDurationSeconds = ffprobeDuration(videoPath);
-    const wallClockSeconds = (wallEnd - wallStart) / 1000;
-
-    return {
-      status: "PASS",
-      newGreeting,
-      txLink,
-      videoPath,
-      videoSize: fs.statSync(videoPath).size,
-      videoDurationSeconds,
-      wallClockSeconds,
-      frameCount: frames.length,
-    };
   } finally {
     if (chrome) {
       const cdpPortForTeardown = chrome.port;
@@ -539,6 +710,78 @@ function cleanupAll({ cwd, baselineDirty }) {
 }
 
 // ---------------------------------------------------------------------------
+// Proof block -- WHY this exists: a video on its own proves nothing. It is a
+// recording of pixels; nobody reviewing a PR can independently verify a
+// claim from watching one. The tx hashes, the arbiscan links, and the raw
+// on-chain read-back ARE the actual proof -- a reviewer can paste a hash
+// into arbiscan or run `cast call` themselves and get the same answer this
+// skill got. That evidence is only useful if it travels WITH the PR
+// automatically; a human copying hashes around after the fact is exactly
+// the step that gets skipped under time pressure and forgotten. So this
+// skill emits a ready-to-paste block after every successful run, and posts
+// it to the PR itself when one is identified, rather than only printing it
+// for a human to relay.
+//
+// KNOWN LIMITATION, stated plainly rather than worked around: the `gh` CLI
+// cannot attach video/image files to a PR body or comment -- only text
+// (links, hashes) travels this way. The actual .mp4/.gif files still need a
+// human to drag them into the GitHub web UI (a PR comment box, or a release
+// asset). This block carries everything EXCEPT the media itself.
+// ---------------------------------------------------------------------------
+function buildProofBlock({ recordingSource, take1, take2 }) {
+  const lines = [];
+  lines.push(`### demo-video proof`);
+  lines.push("");
+  lines.push(`Recorded from \`${recordingSource.branch}\` @ \`${recordingSource.sha}\` (${recordingSource.subject}).`);
+  lines.push("");
+  if (take1?.status === "PASS") {
+    lines.push(`**Take 1 -- terminal (Sepolia deploy, smoke-test Step 9):**`);
+    lines.push(`- Contract: \`${take1.address}\``);
+    lines.push(`- Deploy tx: \`${take1.txHash}\` -- https://sepolia.arbiscan.io/tx/${take1.txHash}`);
+    lines.push("");
+  }
+  if (take2?.status === "PASS") {
+    lines.push(`**Take 2 -- browser (connect wallet + write tx):**`);
+    if (take2.txLink) lines.push(`- Write tx: ${take2.txLink}`);
+    lines.push(`- New value written: \`${take2.newGreeting}\``);
+    if (take2.onChainReadBack) lines.push(`- Independent on-chain read-back (\`cast call ... greeting()\`): ${take2.onChainReadBack}`);
+    lines.push(`- Video duration ${take2.videoDurationSeconds}s vs. wall-clock run duration ${take2.wallClockSeconds}s (should match -- see SKILL.md "the frame-timing trap")`);
+    lines.push("");
+  }
+  lines.push(
+    `_Video files (\`.mp4\`/\`.gif\`) are not attached here -- \`gh\` cannot attach media to a PR body/comment. ` +
+      `Upload them through the GitHub web UI (this comment's edit box, or a release asset) separately; ` +
+      `everything above is independently verifiable without them._`,
+  );
+  return lines.join("\n");
+}
+
+function postProofBlock(cwd, block, prNumber) {
+  let targetPr = prNumber;
+  if (!targetPr) {
+    try {
+      targetPr = execFileSync("gh", ["pr", "view", "--json", "number", "-q", ".number"], { cwd, encoding: "utf8" }).trim();
+    } catch {
+      console.log(`[proof] no --pr given and no PR found for the current branch -- printing only, not posting.`);
+    }
+  }
+  if (!targetPr) return null;
+
+  const tmpPath = path.join(os.tmpdir(), `demo-video-proof-${process.pid}.md`);
+  fs.writeFileSync(tmpPath, block);
+  try {
+    execFileSync("gh", ["pr", "comment", String(targetPr), "--body-file", tmpPath], { cwd, stdio: "inherit" });
+    console.log(`[proof] posted to PR #${targetPr} via 'gh pr comment'.`);
+    return targetPr;
+  } catch (err) {
+    console.error(`[proof] could not post to PR #${targetPr} (${err.message}) -- printing only.`);
+    return null;
+  } finally {
+    fs.rmSync(tmpPath, { force: true });
+  }
+}
+
+// ---------------------------------------------------------------------------
 // CLI
 // ---------------------------------------------------------------------------
 async function main() {
@@ -551,6 +794,16 @@ async function main() {
   const mode = process.argv[2] || "all";
   const report = { mode, outDir };
 
+  if (mode === "cleanup") {
+    cleanupAll({ cwd, baselineDirty: {} });
+    console.log(`\n=== FINAL REPORT ===`);
+    console.log(JSON.stringify(report, null, 2));
+    return;
+  }
+
+  const recordingSource = requireStatedBranch(cwd);
+  report.recordingSource = recordingSource;
+
   const baselineDirty = {
     "packages/nextjs/scaffold.config.ts": isDirty(cwd, "packages/nextjs/scaffold.config.ts"),
     "packages/nextjs/next-env.d.ts": isDirty(cwd, "packages/nextjs/next-env.d.ts"),
@@ -558,20 +811,27 @@ async function main() {
 
   try {
     if (mode === "take1" || mode === "all") {
-      report.take1 = await take1({ outDir, cwd, checkoutRoot });
+      report.take1 = await take1({ outDir, cwd, checkoutRoot, recordingSource });
       console.log(`[main] take1: ${JSON.stringify(report.take1, null, 2)}`);
       if (mode === "all" && report.take1.status !== "PASS") {
         console.log(`[main] take1 status=${report.take1.status}, skipping take2 (nothing deployed to show)`);
       }
     }
     if (mode === "take2" || (mode === "all" && report.take1?.status === "PASS")) {
-      report.take2 = await take2({ outDir, cwd });
+      report.take2 = await take2({ outDir, cwd, checkoutRoot, contractAddress: report.take1?.address, recordingSource });
       console.log(`[main] take2: ${JSON.stringify(report.take2, null, 2)}`);
     }
   } finally {
-    if (mode === "all" || mode === "cleanup") {
+    if (mode === "all") {
       cleanupAll({ cwd, baselineDirty });
     }
+  }
+
+  if (report.take1?.status === "PASS" || report.take2?.status === "PASS") {
+    const block = buildProofBlock({ recordingSource, take1: report.take1, take2: report.take2 });
+    console.log(`\n=== PROOF BLOCK (paste into the PR if not posted automatically) ===\n`);
+    console.log(block);
+    report.postedToPr = postProofBlock(cwd, block, parseCliFlag("pr"));
   }
 
   console.log(`\n=== FINAL REPORT ===`);

--- a/.claude/skills/demo-video/record.mjs
+++ b/.claude/skills/demo-video/record.mjs
@@ -243,7 +243,16 @@ function assembleVideo(frames, outPath, endTimestamp) {
     const cur = frames[i];
     const next = frames[i + 1];
     const nextTs = next ? next.timestamp : endTimestamp;
-    const duration = Math.max(nextTs - cur.timestamp, 0.05);
+    // MEASURED (2026-07-22): a 50ms floor here inflated a real 11.1s run to
+    // a 27s video (2.4x) -- most of the 456 captured frames arrived faster
+    // than 50ms apart (real UI repaints during the connect/switch/write
+    // flow), so flooring every one of those sub-50ms gaps to 50ms compounded
+    // across hundreds of frames into a video whose duration had nothing to
+    // do with the actual run. The floor only needs to be positive enough for
+    // ffmpeg's concat demuxer to accept it, not "watchable per frame" --
+    // 1ms preserves real timing; ffmpeg's own frame rate/codec handles
+    // very-short-duration entries fine.
+    const duration = Math.max(nextTs - cur.timestamp, 0.001);
     lines.push(`file '${cur.file}'`);
     lines.push(`duration ${duration.toFixed(3)}`);
   }

--- a/.claude/skills/demo-video/step9.sh
+++ b/.claude/skills/demo-video/step9.sh
@@ -66,11 +66,21 @@ fi
 
 echo
 echo "=== Step 9d -- deploy (yarn deploy --network sepolia) ==="
-yarn deploy --network sepolia
-DEPLOY_STATUS=$?
+# Tee, don't just run -- Step 9e needs to cross-check the PERSISTED deploy
+# record (packages/stylus/deployments/421614_latest.json) against what THIS
+# run's own deploy command printed. That file persists across runs; an
+# "exited 0 but silently didn't rewrite it" bug would otherwise verify a
+# STALE, previous deployment and still report PASS (this is the same failure
+# class as reading a non-empty extension-settings directory as "vault
+# initialised", or a present Keychain entry as "password correct" -- an
+# artifact EXISTING is not proof it is FROM THIS RUN).
+DEPLOY_LOG=$(mktemp)
+yarn deploy --network sepolia | tee "$DEPLOY_LOG"
+DEPLOY_STATUS=${PIPESTATUS[0]}
 if [ $DEPLOY_STATUS -ne 0 ]; then
   echo "FAIL -- yarn deploy exited $DEPLOY_STATUS"
   write_result FAIL "yarn deploy exited $DEPLOY_STATUS"
+  rm -f "$DEPLOY_LOG"
   exit 1
 fi
 
@@ -79,8 +89,29 @@ echo "=== Step 9e -- read back on-chain state ==="
 DEPLOYMENT_JSON="packages/stylus/deployments/421614_latest.json"
 export DEMO_ADDR=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$DEPLOYMENT_JSON','utf8'))['your-contract'].address)")
 export DEMO_TXHASH=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$DEPLOYMENT_JSON','utf8'))['your-contract'].txHash)")
-echo "Deployed address: $DEMO_ADDR"
-echo "Deploy tx hash:   $DEMO_TXHASH"
+
+# Cross-check: the persisted file's address/tx must match what THIS
+# invocation's own stdout reported (printDeployedAddresses() prints
+# "Address: 0x..." / "Tx Hash: 0x..."). A mismatch (or nothing printed at
+# all) means the file was NOT freshly written by this run -- FAIL, don't
+# silently trust the file.
+STDOUT_ADDR=$(grep -m1 "Address:" "$DEPLOY_LOG" | sed -E 's/.*Address:[[:space:]]*//')
+STDOUT_TXHASH=$(grep -m1 "Tx Hash:" "$DEPLOY_LOG" | sed -E 's/.*Tx Hash:[[:space:]]*//')
+rm -f "$DEPLOY_LOG"
+if [ -z "$STDOUT_ADDR" ] || [ -z "$STDOUT_TXHASH" ]; then
+  echo "FAIL -- could not parse Address/Tx Hash from this run's own deploy output -- refusing to trust $DEPLOYMENT_JSON without it"
+  write_result FAIL "deploy stdout unparseable, cannot confirm $DEPLOYMENT_JSON is from this run"
+  exit 1
+fi
+if [ "$STDOUT_ADDR" != "$DEMO_ADDR" ] || [ "$STDOUT_TXHASH" != "$DEMO_TXHASH" ]; then
+  echo "FAIL -- $DEPLOYMENT_JSON does not match this run's own deploy output:"
+  echo "  file:   address=$DEMO_ADDR txHash=$DEMO_TXHASH"
+  echo "  stdout: address=$STDOUT_ADDR txHash=$STDOUT_TXHASH"
+  write_result FAIL "deployment file/stdout mismatch -- file is stale, not from this run"
+  exit 1
+fi
+echo "Deployed address: $DEMO_ADDR (cross-checked against this run's own deploy output)"
+echo "Deploy tx hash:   $DEMO_TXHASH (cross-checked against this run's own deploy output)"
 cast receipt "$DEMO_TXHASH" --rpc-url "$RPC_URL_SEPOLIA"
 GREETING=$(cast call "$DEMO_ADDR" "greeting()(string)" --rpc-url "$RPC_URL_SEPOLIA")
 OWNER=$(cast call "$DEMO_ADDR" "owner()(address)" --rpc-url "$RPC_URL_SEPOLIA")

--- a/.claude/skills/demo-video/step9.sh
+++ b/.claude/skills/demo-video/step9.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# .claude/skills/demo-video/step9.sh
+#
+# The ACTUAL smoke-test Step 9 procedure (9a-9e; 9f is deferred to
+# record.mjs's cleanupAll(), run after Take 2 -- see the sequencing note in
+# record.mjs). This is invoked by record.mjs under `asciinema record` for
+# Take 1 -- it is not a parallel/demo-only script, it is Step 9 itself.
+#
+# Env vars expected (record.mjs sets these):
+#   ACCOUNT_ADDRESS_SEPOLIA, RPC_URL_SEPOLIA, PRIVATE_KEY_SEPOLIA -- read from
+#     the main checkout's packages/stylus/.env and exported into this
+#     process's environment (this worktree has no .env of its own).
+#   DEMO_RESULT_FILE -- path to write a small JSON result to, so record.mjs
+#     can pick up status/address/txHash without parsing recorded terminal
+#     output.
+set -uo pipefail
+
+write_result() {
+  node -e '
+    const fs = require("fs");
+    fs.writeFileSync(process.env.DEMO_RESULT_FILE, JSON.stringify({
+      status: process.argv[1],
+      reason: process.argv[2] || null,
+      address: process.env.DEMO_ADDR || null,
+      txHash: process.env.DEMO_TXHASH || null,
+    }, null, 2));
+  ' "$1" "${2:-}"
+}
+
+echo "=== Step 9a -- tool gate (cast) ==="
+if ! command -v cast >/dev/null 2>&1; then
+  echo "SKIPPED -- cast (Foundry) not installed. Install: curl -L https://foundry.paradigm.xyz | bash && foundryup"
+  write_result SKIPPED "cast not installed"
+  exit 3
+fi
+cast --version
+
+echo
+echo "=== Step 9b -- credentials gate ==="
+MISSING=""
+[ -z "${ACCOUNT_ADDRESS_SEPOLIA:-}" ] && MISSING="$MISSING ACCOUNT_ADDRESS_SEPOLIA"
+[ -z "${RPC_URL_SEPOLIA:-}" ] && MISSING="$MISSING RPC_URL_SEPOLIA"
+[ -z "${PRIVATE_KEY_SEPOLIA:-}" ] && MISSING="$MISSING PRIVATE_KEY_SEPOLIA"
+if [ -n "$MISSING" ]; then
+  echo "SKIPPED -- Sepolia credentials not set:$MISSING"
+  write_result SKIPPED "missing:$MISSING"
+  exit 3
+fi
+echo "Credentials present (deployer: $ACCOUNT_ADDRESS_SEPOLIA)"
+
+echo
+echo "=== Step 9c -- balance gate ==="
+BALANCE_WEI=$(cast balance --rpc-url "$RPC_URL_SEPOLIA" "$ACCOUNT_ADDRESS_SEPOLIA" 2>&1)
+BALANCE_STATUS=$?
+if [ $BALANCE_STATUS -ne 0 ]; then
+  echo "SKIPPED -- Sepolia RPC unreachable: $BALANCE_WEI"
+  write_result SKIPPED "RPC unreachable"
+  exit 3
+fi
+echo "Balance: $BALANCE_WEI wei"
+if [ "$BALANCE_WEI" = "0" ]; then
+  echo "SKIPPED -- deployer has zero Sepolia ETH. Faucets: https://faucets.chain.link/arbitrum-sepolia"
+  write_result SKIPPED "zero balance"
+  exit 3
+fi
+
+echo
+echo "=== Step 9d -- deploy (yarn deploy --network sepolia) ==="
+yarn deploy --network sepolia
+DEPLOY_STATUS=$?
+if [ $DEPLOY_STATUS -ne 0 ]; then
+  echo "FAIL -- yarn deploy exited $DEPLOY_STATUS"
+  write_result FAIL "yarn deploy exited $DEPLOY_STATUS"
+  exit 1
+fi
+
+echo
+echo "=== Step 9e -- read back on-chain state ==="
+DEPLOYMENT_JSON="packages/stylus/deployments/421614_latest.json"
+export DEMO_ADDR=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$DEPLOYMENT_JSON','utf8'))['your-contract'].address)")
+export DEMO_TXHASH=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$DEPLOYMENT_JSON','utf8'))['your-contract'].txHash)")
+echo "Deployed address: $DEMO_ADDR"
+echo "Deploy tx hash:   $DEMO_TXHASH"
+cast receipt "$DEMO_TXHASH" --rpc-url "$RPC_URL_SEPOLIA"
+GREETING=$(cast call "$DEMO_ADDR" "greeting()(string)" --rpc-url "$RPC_URL_SEPOLIA")
+OWNER=$(cast call "$DEMO_ADDR" "owner()(address)" --rpc-url "$RPC_URL_SEPOLIA")
+echo "greeting(): $GREETING"
+echo "owner():    $OWNER"
+CODE_LEN=$(cast code "$DEMO_ADDR" --rpc-url "$RPC_URL_SEPOLIA" | wc -c | tr -d ' ')
+echo "bytecode length: $CODE_LEN chars"
+if [ "$CODE_LEN" -le 2 ]; then
+  echo "FAIL -- deployed contract has no bytecode"
+  write_result FAIL "empty bytecode at $DEMO_ADDR"
+  exit 1
+fi
+
+echo
+echo "PASS -- Step 9 deploy + read-back complete"
+write_result PASS
+exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ node_modules
 !.vscode/settings.json
 .idea
 .vercel
+
+# cdp-with-wallet skill run state (Chrome PIDs/ports/disabled-extension
+# records for detached processes) -- machine-local, never committed
+.claude/skills/cdp-with-wallet/.cdp-wallet-state.json


### PR DESCRIPTION
## Summary

Adds `.claude/skills/demo-video/` — a repeatable capability that records two takes proving scaffold-stylus works end to end:

1. **Take 1 (terminal)** — wraps smoke-test Step 9 exactly as it exists (real Arbitrum Sepolia deploy), recorded with `asciinema`.
2. **Take 2 (browser)** — drives a real MetaMask connect + write transaction against that deploy via `.claude/skills/cdp-with-wallet`, recorded with Chrome DevTools Protocol's own `Page.startScreencast` (no macOS screen-recording permission needed, works headless/CI).

Stacks on #98 (`chore/phase-1-updates`) — this PR's diff is demo-video + `cdp-with-wallet` only; the gas-fee fix and phase-1 updates are already covered by #98's own description/proof, not repeated here.

## What's included

- `record.mjs` / `step9.sh` — the orchestration (see SKILL.md for the full procedure, the base-branch preflight, the proof-block feature, and everything measured while building this).
- `.claude/skills/cdp-with-wallet/` (from #100) merged in as a dependency, plus two bugs found and fixed while building this: a `Page.screencastFrame`-vs-`once()` gap, and an `approveTx()` render race (same class already fixed in `unlock()`).
- Two staleness cross-checks: `step9.sh` and `record.mjs`'s `take1()` both confirm the deployed contract address actually came from *this* run, not a stale leftover artifact — see SKILL.md "The staleness trap".

## Proof this works (real Sepolia run, `feat/demo-video@f86cd9d`)

**Take 1:**
- Contract: `0x4015656ee96bb6f401c9eb5471dc8f1c9fa57ca8`
- Deploy tx: https://sepolia.arbiscan.io/tx/0x0e31e5a24d99f66e9041d5d2a2bbe06ed27ab06e8c228f5d33f647ebc6de408a

**Take 2:**
- Write tx: https://sepolia.arbiscan.io/tx/0xedfb81691ddb5cfaf32daee805324130e0a4bc9176b06d5fca7bef49c4009cb9
- New value written: `demo-video 2026-07-22T10:09:54.314Z`
- Independent on-chain read-back (`cast call ... greeting()`): `"demo-video 2026-07-22T10:09:54.314Z"`
- Video: 12.08s vs. 12.02s wall-clock (matches — see SKILL.md "the frame-timing trap" for why this comparison matters)

Video/GIF files aren't attached here (`gh` can't attach media) — will be uploaded via the web UI separately.

## Test plan

- [x] `node record.mjs all --branch=feat/demo-video` — real run, both takes PASS (see above)
- [x] Verified independently: `cast receipt`/`cast call` against both tx hashes, not just the script's own report
- [x] `git status --short` clean before/after; no leaked Chrome/frontend processes (`pgrep -fl "remote-debugging|chrome-debug-profile"` empty)
- [ ] Video/GIF files uploaded to this PR via web UI