### PR TITLE
ci: add publish-only workflow for create-stylus

### DIFF
--- a/.github/workflows/publish-create-stylus.yaml
+++ b/.github/workflows/publish-create-stylus.yaml
@@ -1,0 +1,80 @@
+name: Publish create-stylus (dry-run capable)
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "git ref of Arb-Stylus/create-stylus to publish from"
+        type: string
+        default: main
+      dry_run:
+        description: "Run npm publish --dry-run instead of a real publish"
+        type: boolean
+        default: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout create-stylus
+        uses: actions/checkout@v4
+        with:
+          repository: Arb-Stylus/create-stylus
+          ref: ${{ inputs.ref }}
+          token: ${{ secrets.ORG_GITHUB_TOKEN }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org/"
+
+      - name: Auth preflight (npm whoami)
+        run: |
+          WHOAMI=$(npm whoami)
+          echo "Authenticated to npm registry as: ${WHOAMI}"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Echo package to be published
+        run: |
+          PKG_NAME=$(node -p "require('./package.json').name")
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          echo "About to publish ${PKG_NAME}@${PKG_VERSION} (ref=${{ inputs.ref }}, dry_run=${{ inputs.dry_run }})"
+
+      - name: Install dependencies (npm ci)
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish (dry-run)
+        if: ${{ inputs.dry_run }}
+        run: npm publish --dry-run
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish (real)
+        if: ${{ !inputs.dry_run }}
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Notify Slack on Success
+        if: success()
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          slack-message: "✅ Publish create-stylus ${{ inputs.dry_run && '(DRY RUN)' || '' }} Successful!\nRef: ${{ inputs.ref }}\nDry run: ${{ inputs.dry_run }}\nBuild Status: ${{ job.status }}\nTriggered by: ${{ github.actor }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+      - name: Notify Slack on Failure
+        if: failure()
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          slack-message: "❌ Publish create-stylus ${{ inputs.dry_run && '(DRY RUN)' || '' }} Failed!\nRef: ${{ inputs.ref }}\nDry run: ${{ inputs.dry_run }}\nBuild Status: ${{ job.status }}\nTriggered by: ${{ github.actor }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/publish-create-stylus.yaml
+++ b/.github/workflows/publish-create-stylus.yaml
@@ -43,8 +43,9 @@ jobs:
           PKG_VERSION=$(node -p "require('./package.json').version")
           echo "About to publish ${PKG_NAME}@${PKG_VERSION} (ref=${{ inputs.ref }}, dry_run=${{ inputs.dry_run }})"
 
-      - name: Install dependencies (npm ci)
-        run: npm ci
+      # npm install, not npm ci: create-stylus is a yarn@3 repo with no package-lock.json.
+      - name: Install dependencies (npm install)
+        run: npm install
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
> ⚠️ MERGE THIS WITH `[skip ci]` IN THE MERGE COMMIT MESSAGE. Merging without it triggers
> `release-create-stylus.yaml`, which will bump 0.2.0 → 0.2.1 on both repos and push tags.

## Summary

- `create-stylus@0.2.0` is committed on `main` @ `5c82c64` but was never published to npm — the
  release run died at `npm publish` with `E404 PUT https://registry.npmjs.org/create-stylus`
  because `NPM_TOKEN` lacked publish rights. The token has since been rotated (2026-07-29).
- `release-create-stylus.yaml` can't be reused to recover this: it's `pull_request: closed`
  triggered and its first action is `npm version` on both repos, so re-running it would bump
  0.2.0 → 0.2.1 instead of publishing the existing 0.2.0.
- Adds `.github/workflows/publish-create-stylus.yaml`, a new `workflow_dispatch`-only workflow
  with **no** `npm version` / `git push` / `git tag` / `rsync` step anywhere in the file — it is
  structurally incapable of bumping versions, not just guarded by an `if:`.
- `dry_run` input defaults to `true` so a mis-click never publishes. When true it runs
  `npm publish --dry-run` instead of a real publish.
- Includes an `npm whoami` auth preflight (fails the job on failure) so the rotated token's
  publish rights can be verified before anything is written to the registry.
- Does not modify `release-create-stylus.yaml` or any other file.

## Test plan

- [x] `actionlint .github/workflows/publish-create-stylus.yaml` — exit 0, no findings.
- [x] `grep -nE "npm version|git push|git tag|rsync" .github/workflows/publish-create-stylus.yaml` — empty.
- [x] `git diff --stat main` — exactly one file added (`publish-create-stylus.yaml`, +80).
- [x] Install step was originally `npm ci`, but `npm ci` is rejected because `create-stylus`
      ships only `yarn.lock`/`.yarnrc.yml` (`packageManager: yarn@3.5.0`) and has no
      `package-lock.json`. Switched to `npm install` to match the install step in
      `release-create-stylus.yaml`, the sequence that already published 0.1.17 successfully.
      Not switching the workflow to yarn — this is a recovery publish and should reproduce what
      the original release would have done.
- [ ] Not run by me: actually dispatching the workflow (dry-run or real) — left for a human to trigger.
