### PR TITLE
docs(readme): update dead website domain to scaffoldstylus.quantum3labs.com

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 <h4 align="center">
   <a href="https://arb-stylus.github.io/scaffold-stylus-docs/">Documentation</a> |
-  <a href="https://www.scaffoldstylus.com/">Website</a>
+  <a href="https://scaffoldstylus.quantum3labs.com/">Website</a>
 </h4>
 
 🧪 An open-source, up-to-date toolkit for building decentralized applications (dapps) on the Arbitrum blockchain. It's designed to make it easier for developers to create and deploy smart contracts and build user interfaces that interact with those contracts.
@@ -295,7 +295,7 @@ Visit our [Troubleshooting section](https://arb-stylus.github.io/scaffold-stylus
 
 Visit our [docs](https://arb-stylus.github.io/scaffold-stylus-docs/) to learn how to start building with Scaffold-Stylus.
 
-To learn more about its features, check out our [website](https://www.scaffoldstylus.com/).
+To learn more about its features, check out our [website](https://scaffoldstylus.quantum3labs.com/).
 
 ## Contributing to Scaffold-Stylus
 


### PR DESCRIPTION
## Summary

- `https://www.scaffoldstylus.com/` is dead (SSL error, verified by curl).
- New live domain `https://scaffoldstylus.quantum3labs.com/` verified 200.
- Updates the two website links in `readme.md` (Website badge link + features section mention).

## Urgency

ETH Lima hackathon starts tonight. `create-stylus`'s `templates/base/readme.md` is rsync'd FROM this file — if this fix doesn't land before the next sync, it will regress the domain fix already shipped in `create-stylus` PR #14.

## Test plan

- [x] `grep -rIn --exclude-dir=node_modules --exclude-dir=.git -i scaffoldstylus . | grep -v quantum3labs` returns no real content hits (only the worktree's internal `.git` pointer file path, not readme content).
- [x] Confirmed diff is exactly 2 lines changed in `readme.md`, no other files touched.

**Do not merge** — awaiting explicit go-ahead.