### PR TITLE
chore: set version to 1.2.0 to clear the abandoned npm 1.1.x ceiling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ss",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "private": true,
   "workspaces": {
     "packages": [


### PR DESCRIPTION
## Summary

- Sets the root `package.json` version to 1.2.0 (from 1.0.0).
- No other files changed.

## Background

An earlier release today accidentally jumped to a major version because a merge-commit body happened to contain a bracketed keyword that the release workflow greps for. That release has already published to npm and is clean of the dead-domain issue.

npm also has an abandoned line published in mid-2025 (in the 1.1.0 to 1.1.4 range) that still carries the dead `www.scaffoldstylus.com` domain. If we unpublished today's release, npm would recompute `latest` to that abandoned line, and caret-range installs pinned to the same major would resolve there too — reintroducing the dead domain mid-hackathon. So we are not rolling back; this PR publishes forward, above that abandoned line, so both `latest` and caret-range installs resolve to a current, clean release.

## Note for reviewer

`packages/stylus/package.json` also currently carries a literal version string of `1.0.0`, but git history shows it was last touched by an unrelated cargo-stylus migration commit, not by the release automation that bumps the root `package.json`. Flagging it here for a decision — not changed in this PR.

**Do not merge** — awaiting explicit go-ahead.