### PR TITLE
fix(release-workflow): commit-subject-only bump detection + npm-registry version floor

### DIFF
--- a/.github/workflows/release-create-stylus.yaml
+++ b/.github/workflows/release-create-stylus.yaml
@@ -51,7 +51,7 @@ jobs:
         id: version
         run: |
           cd source_repo
-          commit_message=$(git log -1 --pretty=%B)
+          commit_message=$(git log -1 --pretty=%s)
           if [[ "$commit_message" == *"[major]"* ]]; then
             echo "type=major" >> "$GITHUB_ENV"
           elif [[ "$commit_message" == *"[minor]"* ]]; then
@@ -111,6 +111,17 @@ jobs:
           git add .
           git commit -m "Processed $gitignore_file into $mjs_file"
 
+      - name: Align destination version with npm registry
+        run: |
+          cd destination_repo
+          PKG=$(node -p "require('./package.json').name")
+          HIGHEST=$(npm view "$PKG" versions --json | grep -oE '[0-9]+\.[0-9]+\.[0-9]+[^"]*' | sort -V | tail -1)
+          LOCAL=$(node -p "require('./package.json').version")
+          BASE=$(printf '%s\n%s\n' "$HIGHEST" "$LOCAL" | sort -V | tail -1)
+          echo "highest_published=$HIGHEST local=$LOCAL base=$BASE"
+          npm version "$BASE" --no-git-tag-version --allow-same-version
+          echo "HIGHEST=$HIGHEST" >> "$GITHUB_ENV"
+
       - name: Bump version in Destination Repository
         id: bump-version-destination
         run: |
@@ -118,6 +129,26 @@ jobs:
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           new_version=$(npm version ${{ env.type }} -m "chore(release): %s [skip ci]")
+          NEW=$(node -p "require('./package.json').version")
+          node -e '
+            const [a, b] = process.argv.slice(1);
+            const parse = v => { const [core, ...r] = v.split("-"); return { n: core.split(".").map(Number), p: r.join("-") }; };
+            const pa = parse(a), pb = parse(b);
+            for (let i = 0; i < 3; i++) { if (pa.n[i] !== pb.n[i]) process.exit(pa.n[i] > pb.n[i] ? 0 : 1); }
+            if (pa.p === pb.p) process.exit(0);
+            if (!pa.p) process.exit(0);
+            if (!pb.p) process.exit(1);
+            const ai = pa.p.split("."), bi = pb.p.split(".");
+            for (let i = 0; i < Math.max(ai.length, bi.length); i++) {
+              if (ai[i] === undefined) process.exit(0);
+              if (bi[i] === undefined) process.exit(1);
+              const an = /^[0-9]+$/.test(ai[i]), bn = /^[0-9]+$/.test(bi[i]);
+              if (an && bn) { const d = Number(ai[i]) - Number(bi[i]); if (d !== 0) process.exit(d > 0 ? 0 : 1); }
+              else if (an !== bn) process.exit(an ? 1 : 0);
+              else if (ai[i] !== bi[i]) process.exit(ai[i] < bi[i] ? 1 : 0);
+            }
+            process.exit(0);
+          ' "$NEW" "$HIGHEST" || { echo "::error::Computed $NEW is not above highest published $HIGHEST"; exit 1; }
           git push origin main --follow-tags
 
       - name: Set up Node.js


### PR DESCRIPTION
## Summary

Fixes `.github/workflows/release-create-stylus.yaml`, the workflow behind both of today's create-stylus release incidents (accidental major bump to 1.0.0, then the abandoned 1.1.x npm line). Scope is this workflow file only — does not touch the `dist/` rsync-exclude issue or the `.npmrc` template issue; those are tracked separately.

- **Bump-type detection now reads only the commit subject.** `Determine version bump type` switched from `git log -1 --pretty=%B` (subject+body) to `--pretty=%s` (subject only). A merge-commit **body** containing a bracketed bump-level word (e.g. the words "major", "minor", "hotfix", or "prerelease" in brackets) is what silently promoted create-stylus to 1.0.0 today — GitHub's default squash-merge body pulls in PR description text, which can contain that pattern incidentally. The skip-ci detection step (`check if skip ci`, still reading `--pretty=%B`) is intentionally untouched — a skip-ci marker in a commit body should still skip the run.
- **New "Align destination version with npm registry" step**, inserted before the destination bump. It reads `npm view <pkg> versions --json` (the full list of published versions, not the `latest` dist-tag) and resets the destination `package.json` to the higher of that and the local version. This morning `latest` pointed at 1.0.0 while 1.1.4 had actually been published, so using the singular dist-tag query would have reintroduced the exact bug — this uses the full version list plus `sort -V` instead.
- **New guard after the destination bump.** Hard-fails the run (`::error` + `exit 1`) if the freshly bumped version is not semver-above the highest published version, so a bad computed version blocks the push and publish instead of going out silently. I placed this guard **inside** the same step as the bump, before `git push`, rather than as a separate step — this blocks the bad commit from ever reaching the destination repo's `main`, not just from being published to npm.

## Investigated: does `sort -V` misorder prereleases?

Verified on GNU coreutils 9.4 (Ubuntu 24.04, matching the real `ubuntu-latest` GitHub Actions image — confirmed via Docker; `ubuntu:latest` on Docker Hub is actually 26.04 with `uutils coreutils`, so I tested both and they agree) and cross-checked against `npm`'s own bundled `semver` package:

`sort -V` is **not** semver-correct for prerelease identifiers. It ranks `1.0.0-rc.1` as *greater* than `1.0.0`, because it's a natural/filename version sort, not a semver comparator — real semver says a release always outranks its own prereleases (`1.0.0 > 1.0.0-rc.1`).

Traced the actual impact through both new steps:

- **Alignment step's `sort -V` max-of-two:** benign in this bug's specific shape. It only misorders when the two candidates share an identical core `X.Y.Z` and one carries a prerelease suffix — and in exactly that situation, npm's own `npm version <patch|minor|major>` graduation logic (verified directly: `semver.inc('1.2.3-rc.1','patch') → '1.2.3'`, `minor → '1.3.0'`, `major → '2.0.0'`) only looks at the numeric core and discards any existing prerelease tag. So even if this step picks the "wrong" (rc-tagged) side of a core-equal comparison, the very next ordinary bump produces the identical final version either way. Left this step using `sort -V` over the full version list as specified — it's the correct tool there and the trap (must use `versions` plural, not the `latest` dist-tag singular) is unrelated to this issue.
- **The new guard, however, is not self-correcting** — it's the terminal check. If the highest published version is currently a prerelease (e.g. `1.0.0-rc.1`, from a prior prerelease-type run) and the next ordinary release correctly graduates to `1.0.0`, a `sort -V`-based comparison would rank `1.0.0-rc.1` above `1.0.0` and **fail the guard on a legitimate, correct release** — the exact "genuinely broken" case. So the guard uses a small inline semver-aware comparator (Node, no new dependency — `node` is already required by the existing `npm version`/`node -p` calls in this workflow) instead of `sort -V`. Verified it against the concrete cases: `1.0.0 >= 1.0.0-rc.1` → pass, `1.0.0-rc.1 >= 1.0.0` → correctly fail, `1.0.0-rc.2 >= 1.0.0-rc.1` → pass, `1.3.0 >= 1.0.0-rc.1` → pass.

## ⚠️ Merge warning

This workflow triggers on `pull_request` `closed` with `merged: true` against `main` — **merging this PR fires a release and auto-publishes to npm.** With the new alignment step in place, the registry floor becomes 1.2.0, so an ordinary merge would compute and publish 1.2.1.

**Recommend merging with the skip-ci marker (`[skip ci]`) in the squash-merge commit message**, so this fix lands without publishing. The next ordinary feature merge will then be the first to exercise the corrected logic.

## Do not merge

Opening for review only, per instruction — not merging this PR.