### PR TITLE
fix(write): stop simulate pre-check from false-positive insufficient-funds

### DIFF
--- a/packages/nextjs/utils/scaffold-eth/contract.ts
+++ b/packages/nextjs/utils/scaffold-eth/contract.ts
@@ -26,8 +26,15 @@ import {
   keccak256,
   toHex,
 } from "viem";
+import { estimateContractGas } from "viem/actions";
 import { Config, UseReadContractParameters, UseWatchContractEventParameters, UseWriteContractParameters } from "wagmi";
-import { WriteContractParameters, WriteContractReturnType, simulateContract } from "wagmi/actions";
+import {
+  WriteContractParameters,
+  WriteContractReturnType,
+  getClient,
+  getConnectorClient,
+  simulateContract,
+} from "wagmi/actions";
 import { WriteContractVariables } from "wagmi/query";
 import deployedContractsData from "~~/contracts/deployedContracts";
 import externalContractsData from "~~/contracts/externalContracts";
@@ -414,7 +421,18 @@ export const simulateContractWriteAndNotifyError = async ({
   chainId: AllowedChainIds;
 }) => {
   try {
-    await simulateContract(wagmiConfig, params);
+    // Some RPC nodes default an omitted `gas` field on eth_call to an oversized value (e.g. 50,000,000)
+    // and check the sender's balance against that inflated hypothetical cost, producing a false
+    // "insufficient funds" error even when the real gas cost is trivial. Estimating gas first and
+    // passing it through avoids that RPC-side default. The estimate must run as the connected
+    // account (mirroring what wagmi's own simulateContract resolves internally), since owner-gated
+    // functions revert when estimated from an unset/zero account.
+    const account =
+      params.account ??
+      (await getConnectorClient(wagmiConfig, { assertChainId: false, chainId: chainId as any })).account;
+    const client = getClient(wagmiConfig, { chainId: chainId as any })!;
+    const gas = await estimateContractGas(client, { ...params, account } as any);
+    await simulateContract(wagmiConfig, { ...params, gas });
   } catch (error) {
     const parsedError = getParsedErrorWithAllAbis(error, chainId);
 


### PR DESCRIPTION
## Summary

Every write transaction was being blocked by a **false-positive "insufficient funds" error** at the pre-flight simulate step, independent of the wallet's actual balance.

## Root cause

`simulateContractWriteAndNotifyError` (`packages/nextjs/utils/scaffold-eth/contract.ts`) calls viem's `simulateContract` (an `eth_call` under the hood) without an explicit `gas` field. Verified directly against the Arbitrum Sepolia RPC (`sepolia-rollup.arbitrum.io/rpc`):

- With `gas` omitted, this node defaults the field to a fixed, oversized value (50,000,000) and checks the sender's balance against **that** hypothetical cost, not the transaction's real cost.
- The same `eth_call`, with a realistic explicit `gas` value, succeeds immediately.
- A direct `eth_estimateGas` call for the same transaction returned ~49,880 — the wallet's actual balance covered that with room to spare.

So the simulate step wasn't reporting a real balance shortfall; it was comparing the balance against a number the RPC made up because no gas limit was supplied.

## Fix

Estimate gas first, then pass that real number into the simulate call so it never falls through to the RPC's inflated default.

The estimate has to run **as the connected account** — resolved the same way wagmi's own `simulateContract` resolves it internally (`account ?? (await getConnectorClient(...)).account`) — because owner-gated functions (e.g. `withdraw()`) revert when gas-estimated from an unset/zero account. Without this, the fix would trade one false negative for another: legitimate owner-only writes would start failing the pre-check with a misleading revert instead of the misleading balance error.

## Blast radius

`simulateContractWriteAndNotifyError` is called from two places:
- `WriteOnlyFunctionForm.tsx:63` — the Debug page
- `useScaffoldWriteContract.ts:152` — the write hook every user-built dapp uses

This affected **every write transaction through the scaffold**, not just the Debug UI.

## Verification

- Confirmed via direct RPC calls (`eth_call` with/without explicit `gas`, `eth_estimateGas`) that the root-cause behavior is exactly as described above.
- Applied the fix locally, reloaded the Debug page, and reproduced a real write end-to-end.
- Independently verified on-chain post-fix: `cast call greeting()` on the target contract returned the value set by the write, confirming the transaction actually landed.
- `yarn next:check-types` and eslint pass on the changed file (enforced by the pre-commit hook).

## Scope

This PR touches only `packages/nextjs/utils/scaffold-eth/contract.ts`. It intentionally excludes three other files that were dirtied by manual on-chain test setup in the same working tree (`scaffold.config.ts`, `contracts/deployedContracts.ts` temporarily pointed at a test network/contract, and an unrelated pre-existing `next-env.d.ts` diff) — none of those belong in this fix.

## Do not merge

Opening for review only, per instruction — not merging this PR.